### PR TITLE
query init only once

### DIFF
--- a/src/scoping/langs/csharp.rs
+++ b/src/scoping/langs/csharp.rs
@@ -1,8 +1,5 @@
 use super::{CodeQuery, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::{
-    find::Find,
-    scoping::{langs::IGNORE, scope::RangesWithContext, Scoper},
-};
+use crate::{find::Find, scoping::langs::IGNORE};
 use clap::ValueEnum;
 use const_format::formatcp;
 use std::{fmt::Debug, str::FromStr};
@@ -75,12 +72,6 @@ impl From<CustomCSharpQuery> for TSQuery {
     fn from(value: CustomCSharpQuery) -> Self {
         TSQuery::new(&CSharp::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for CSharp {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 

--- a/src/scoping/langs/csharp.rs
+++ b/src/scoping/langs/csharp.rs
@@ -80,7 +80,7 @@ impl From<CustomCSharpQuery> for TSQuery {
 
 impl Scoper for CSharp {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -89,8 +89,12 @@ impl LanguageScoper for CSharp {
         tree_sitter_c_sharp::language()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/go.rs
+++ b/src/scoping/langs/go.rs
@@ -79,7 +79,7 @@ impl From<CustomGoQuery> for TSQuery {
 
 impl Scoper for Go {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -88,8 +88,12 @@ impl LanguageScoper for Go {
         tree_sitter_go::language()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/go.rs
+++ b/src/scoping/langs/go.rs
@@ -1,8 +1,5 @@
 use super::{CodeQuery, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::{
-    find::Find,
-    scoping::{langs::IGNORE, scope::RangesWithContext, Scoper},
-};
+use crate::{find::Find, scoping::langs::IGNORE};
 use clap::ValueEnum;
 use const_format::formatcp;
 use std::{fmt::Debug, str::FromStr};
@@ -74,12 +71,6 @@ impl From<CustomGoQuery> for TSQuery {
     fn from(value: CustomGoQuery) -> Self {
         TSQuery::new(&Go::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for Go {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 

--- a/src/scoping/langs/hcl.rs
+++ b/src/scoping/langs/hcl.rs
@@ -259,7 +259,7 @@ impl From<CustomHclQuery> for TSQuery {
 
 impl Scoper for Hcl {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -268,8 +268,12 @@ impl LanguageScoper for Hcl {
         tree_sitter_hcl::language()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/hcl.rs
+++ b/src/scoping/langs/hcl.rs
@@ -1,8 +1,5 @@
 use super::{CodeQuery, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::{
-    find::Find,
-    scoping::{langs::IGNORE, scope::RangesWithContext, Scoper},
-};
+use crate::{find::Find, scoping::langs::IGNORE};
 use clap::ValueEnum;
 use const_format::formatcp;
 use std::{fmt::Debug, str::FromStr};
@@ -254,12 +251,6 @@ impl From<CustomHclQuery> for TSQuery {
     fn from(value: CustomHclQuery) -> Self {
         TSQuery::new(&Hcl::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for Hcl {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 

--- a/src/scoping/langs/mod.rs
+++ b/src/scoping/langs/mod.rs
@@ -120,7 +120,7 @@ pub(super) const IGNORE: &str = "_SRGN_IGNORE";
 /// A scoper for a language.
 ///
 /// Functions much the same, but provides specific language-related functionality.
-pub trait LanguageScoper: Scoper + Find {
+pub trait LanguageScoper: Find + Send + Sync {
     /// The language's tree-sitter language.
     fn lang() -> TSLanguage
     where
@@ -202,5 +202,14 @@ pub trait LanguageScoper: Scoper + Find {
             Some(nq) => ranges - run(nq),
             None => ranges,
         }
+    }
+}
+
+impl<T> Scoper for T
+where
+    T: LanguageScoper,
+{
+    fn scope_raw<'viewee>(&self, input: &'viewee str) -> super::scope::RangesWithContext<'viewee> {
+        self.scope_via_query(input).into()
     }
 }

--- a/src/scoping/langs/python.rs
+++ b/src/scoping/langs/python.rs
@@ -1,5 +1,5 @@
 use super::{CodeQuery, Find, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::scoping::{langs::IGNORE, scope::RangesWithContext, Scoper};
+use crate::scoping::langs::IGNORE;
 use clap::ValueEnum;
 use const_format::formatcp;
 use std::{fmt::Debug, str::FromStr};
@@ -111,12 +111,6 @@ impl From<CustomPythonQuery> for TSQuery {
     fn from(value: CustomPythonQuery) -> Self {
         TSQuery::new(&Python::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for Python {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 

--- a/src/scoping/langs/python.rs
+++ b/src/scoping/langs/python.rs
@@ -116,7 +116,7 @@ impl From<CustomPythonQuery> for TSQuery {
 
 impl Scoper for Python {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -125,8 +125,12 @@ impl LanguageScoper for Python {
         tree_sitter_python::language()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/rust.rs
+++ b/src/scoping/langs/rust.rs
@@ -96,7 +96,7 @@ impl From<CustomRustQuery> for TSQuery {
 
 impl Scoper for Rust {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -105,8 +105,12 @@ impl LanguageScoper for Rust {
         tree_sitter_rust::language()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/rust.rs
+++ b/src/scoping/langs/rust.rs
@@ -1,5 +1,4 @@
 use super::{CodeQuery, Find, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::scoping::{scope::RangesWithContext, Scoper};
 use clap::ValueEnum;
 use std::{fmt::Debug, str::FromStr};
 use tree_sitter::QueryError;
@@ -91,12 +90,6 @@ impl From<CustomRustQuery> for TSQuery {
     fn from(value: CustomRustQuery) -> Self {
         TSQuery::new(&Rust::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for Rust {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 

--- a/src/scoping/langs/typescript.rs
+++ b/src/scoping/langs/typescript.rs
@@ -59,7 +59,7 @@ impl From<CustomTypeScriptQuery> for TSQuery {
 
 impl Scoper for TypeScript {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        Self::scope_via_query(&mut self.query(), input).into()
+        self.scope_via_query(input).into()
     }
 }
 
@@ -68,8 +68,12 @@ impl LanguageScoper for TypeScript {
         tree_sitter_typescript::language_typescript()
     }
 
-    fn query(&self) -> TSQuery {
-        self.query.clone().into()
+    fn pos_query(&self) -> &TSQuery {
+        &self.positive_query
+    }
+
+    fn neg_query(&self) -> Option<&TSQuery> {
+        self.negative_query.as_ref()
     }
 }
 

--- a/src/scoping/langs/typescript.rs
+++ b/src/scoping/langs/typescript.rs
@@ -1,5 +1,4 @@
 use super::{CodeQuery, Find, Language, LanguageScoper, TSLanguage, TSQuery};
-use crate::scoping::{scope::RangesWithContext, Scoper};
 use clap::ValueEnum;
 use std::{fmt::Debug, str::FromStr};
 use tree_sitter::QueryError;
@@ -54,12 +53,6 @@ impl From<CustomTypeScriptQuery> for TSQuery {
     fn from(value: CustomTypeScriptQuery) -> Self {
         TSQuery::new(&TypeScript::lang(), &value.0)
             .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl Scoper for TypeScript {
-    fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
-        self.scope_via_query(input).into()
     }
 }
 


### PR DESCRIPTION
- **fix(language-scoping): Construct `TSQuery` only once**
- **chore(language-scoping): Blanket `impl Scoper` for all `LanguageScoper`**
