### PR TITLE
`--[lang]-query` can read tree-sitter (scm) query files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1607,7 +1607,7 @@ Language scopes:
 
       --csharp-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope C# code using a custom tree-sitter query. The query can be given inline or
-          if as a path to a file containing a query.
+          as a path to a file containing a query.
           
           [env: CSHARP_QUERY=]
 
@@ -1641,7 +1641,7 @@ Language scopes:
 
       --go-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Go code using a custom tree-sitter query. The query can be given inline or
-          if as a path to a file containing a query.
+          as a path to a file containing a query.
           
           [env: GO_QUERY=]
 
@@ -1669,7 +1669,7 @@ Language scopes:
 
       --hcl-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope HashiCorp Configuration Language code using a custom tree-sitter query.
-          The query can be given inline or if as a path to a file containing a query.
+          The query can be given inline or as a path to a file containing a query.
           
           [env: HCL_QUERY=]
 
@@ -1709,7 +1709,7 @@ Language scopes:
 
       --python-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Python code using a custom tree-sitter query. The query can be given
-          inline or if as a path to a file containing a query.
+          inline or as a path to a file containing a query.
           
           [env: PYTHON_QUERY=]
 
@@ -1770,7 +1770,7 @@ Language scopes:
 
       --rust-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Rust code using a custom tree-sitter query. The query can be given inline
-          or if as a path to a file containing a query.
+          or as a path to a file containing a query.
           
           [env: RUST_QUERY=]
 
@@ -1804,7 +1804,7 @@ Language scopes:
 
       --typescript-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope TypeScript code using a custom tree-sitter query. The query can be given
-          inline or if as a path to a file containing a query.
+          inline or as a path to a file containing a query.
           
           [env: TYPESCRIPT_QUERY=]
 

--- a/README.md
+++ b/README.md
@@ -1572,7 +1572,8 @@ Language scopes:
           - call-expression: Call expression
 
       --c-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope C code using a custom tree-sitter query.
+          Scope C code using a custom tree-sitter query. The query can be given inline or
+          if as a path to a file containing a query.
           
           [env: C_QUERY=]
 
@@ -1601,7 +1602,8 @@ Language scopes:
           - identifier:           Identifier names
 
       --csharp-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope C# code using a custom tree-sitter query.
+          Scope C# code using a custom tree-sitter query. The query can be given inline or
+          if as a path to a file containing a query.
           
           [env: CSHARP_QUERY=]
 
@@ -1634,7 +1636,8 @@ Language scopes:
           - struct-tags: Struct tags
 
       --go-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope Go code using a custom tree-sitter query.
+          Scope Go code using a custom tree-sitter query. The query can be given inline or
+          if as a path to a file containing a query.
           
           [env: GO_QUERY=]
 
@@ -1662,6 +1665,7 @@ Language scopes:
 
       --hcl-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope HashiCorp Configuration Language code using a custom tree-sitter query.
+          The query can be given inline or if as a path to a file containing a query.
           
           [env: HCL_QUERY=]
 
@@ -1700,7 +1704,8 @@ Language scopes:
           - identifiers:          Identifiers (variable names, ...)
 
       --python-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope Python code using a custom tree-sitter query.
+          Scope Python code using a custom tree-sitter query. The query can be given
+          inline or if as a path to a file containing a query.
           
           [env: PYTHON_QUERY=]
 
@@ -1760,7 +1765,8 @@ Language scopes:
             `unsafe Trait`, `unsafe impl Trait`)
 
       --rust-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope Rust code using a custom tree-sitter query.
+          Scope Rust code using a custom tree-sitter query. The query can be given inline
+          or if as a path to a file containing a query.
           
           [env: RUST_QUERY=]
 
@@ -1793,7 +1799,8 @@ Language scopes:
           - export:         `export` blocks
 
       --typescript-query <TREE-SITTER-QUERY-OR-FILENAME>
-          Scope TypeScript code using a custom tree-sitter query.
+          Scope TypeScript code using a custom tree-sitter query. The query can be given
+          inline or if as a path to a file containing a query.
           
           [env: TYPESCRIPT_QUERY=]
 

--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,11 @@ Typing out tree-sitter queries at the CLI can be unwieldy. To mitigate this you 
 Below we use the same Python file from the previous section with an invocation of
 
 ```bash
-cat cond.py | srgn --python-query 'docs/python_cond_query.scm' --fail-any # will fail
+cat cond.py | srgn --python-query 'docs/python_cond_query.scm' 
+1:if x:
+2:    return left
+3:else:
+4:    return right
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1577,7 +1577,7 @@ Language scopes:
 
       --c-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope C code using a custom tree-sitter query. The query can be given inline or
-          if as a path to a file containing a query.
+          as a path to a file containing a query.
           
           [env: C_QUERY=]
 

--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,17 @@ which can be caught as:
 cat sensitive.go | srgn --go-query '(field_declaration name: (field_identifier) @name tag: (raw_string_literal) @tag (#match? @name "[tT]oken") (#not-eq? @tag "`json:\"-\"`"))' --fail-any # will fail
 ```
 
+##### Custom queries from file
+
+Typing out tree-sitter queries at the CLI can be unwieldy. To mitigate this you can read queries from [file](docs/query/python_cond_query.scm).
+
+Below we use the same Python file from the previous section with an invocation of
+
+```bash
+cat cond.py | srgn --python-query 'docs/python_cond_query.scm' --fail-any # will fail
+```
+
+
 ###### Ignoring parts of matches
 
 Occassionally, parts of a match need to be ignored, for example when no suitable
@@ -1560,7 +1571,7 @@ Language scopes:
           - declaration:     Declaration
           - call-expression: Call expression
 
-      --c-query <TREE-SITTER-QUERY>
+      --c-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope C code using a custom tree-sitter query.
           
           [env: C_QUERY=]
@@ -1589,7 +1600,7 @@ Language scopes:
           - attribute:            Attribute names
           - identifier:           Identifier names
 
-      --csharp-query <TREE-SITTER-QUERY>
+      --csharp-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope C# code using a custom tree-sitter query.
           
           [env: CSHARP_QUERY=]
@@ -1622,7 +1633,7 @@ Language scopes:
           - goto:        `goto` statements
           - struct-tags: Struct tags
 
-      --go-query <TREE-SITTER-QUERY>
+      --go-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Go code using a custom tree-sitter query.
           
           [env: GO_QUERY=]
@@ -1649,7 +1660,7 @@ Language scopes:
           - comments:       Comments
           - strings:        Literal strings
 
-      --hcl-query <TREE-SITTER-QUERY>
+      --hcl-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope HashiCorp Configuration Language code using a custom tree-sitter query.
           
           [env: HCL_QUERY=]
@@ -1688,7 +1699,7 @@ Language scopes:
           - types:                Types in type hints
           - identifiers:          Identifiers (variable names, ...)
 
-      --python-query <TREE-SITTER-QUERY>
+      --python-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Python code using a custom tree-sitter query.
           
           [env: PYTHON_QUERY=]
@@ -1748,7 +1759,7 @@ Language scopes:
           - unsafe:           `unsafe` keyword usages (`unsafe fn`, `unsafe` blocks,
             `unsafe Trait`, `unsafe impl Trait`)
 
-      --rust-query <TREE-SITTER-QUERY>
+      --rust-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope Rust code using a custom tree-sitter query.
           
           [env: RUST_QUERY=]
@@ -1781,7 +1792,7 @@ Language scopes:
           - namespace:      `namespace` blocks
           - export:         `export` blocks
 
-      --typescript-query <TREE-SITTER-QUERY>
+      --typescript-query <TREE-SITTER-QUERY-OR-FILENAME>
           Scope TypeScript code using a custom tree-sitter query.
           
           [env: TYPESCRIPT_QUERY=]

--- a/docs/python_cond_query.scm
+++ b/docs/python_cond_query.scm
@@ -1,0 +1,6 @@
+(if_statement
+  consequence: (block
+    (return_statement (identifier)))
+  alternative: (else_clause
+    body: (block
+      (return_statement (identifier))))) @cond

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //! ```rust
 //! use srgn::scoping::langs::{
 //!     python::{CompiledQuery, PreparedQuery},
-//!     RawQuery
+//!     QuerySource
 //! };
 //! use srgn::scoping::view::ScopedViewBuilder;
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -1345,6 +1345,7 @@ mod cli {
             .open(query_or_path.as_str())
         {
             Ok(mut file) => {
+                info!("Query points to a valid file at '{}', will use its contents.", file.path());
                 let mut s = String::new();
                 file.read_to_string(&mut s)?;
                 Ok(QuerySource::from(s))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1392,7 +1392,7 @@ mod cli {
 
         #[allow(clippy::doc_markdown)] // CamelCase detected as 'needs backticks'
         /// Scope HashiCorp Configuration Language code using a custom tree-sitter query.
-        /// The query can be given inline or if as a path to a file containing a query.
+        /// The query can be given inline or as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         hcl_query: Vec<QuerySourceOrPath>,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1376,7 +1376,7 @@ mod cli {
         c: Vec<c::PreparedQuery>,
 
         /// Scope C code using a custom tree-sitter query. The query can be given inline or
-        /// if as a path to a file containing a query.
+        /// as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         c_query: Vec<QuerySourceOrPath>,
     }
@@ -1389,7 +1389,7 @@ mod cli {
         csharp: Vec<csharp::PreparedQuery>,
 
         /// Scope C# code using a custom tree-sitter query. The query can be given inline or
-        /// if as a path to a file containing a query.
+        /// as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         csharp_query: Vec<QuerySourceOrPath>,
     }
@@ -1417,7 +1417,7 @@ mod cli {
         go: Vec<go::PreparedQuery>,
 
         /// Scope Go code using a custom tree-sitter query. The query can be given inline or
-        /// if as a path to a file containing a query.
+        /// as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         go_query: Vec<QuerySourceOrPath>,
     }
@@ -1430,7 +1430,7 @@ mod cli {
         python: Vec<python::PreparedQuery>,
 
         /// Scope Python code using a custom tree-sitter query. The query can be given
-        /// inline or if as a path to a file containing a query.
+        /// inline or as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         python_query: Vec<QuerySourceOrPath>,
     }
@@ -1443,7 +1443,7 @@ mod cli {
         rust: Vec<rust::PreparedQuery>,
 
         /// Scope Rust code using a custom tree-sitter query. The query can be given inline
-        /// or if as a path to a file containing a query.
+        /// or as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         rust_query: Vec<QuerySourceOrPath>,
     }
@@ -1456,7 +1456,7 @@ mod cli {
         typescript: Vec<typescript::PreparedQuery>,
 
         /// Scope TypeScript code using a custom tree-sitter query. The query can be given
-        /// inline or if as a path to a file containing a query.
+        /// inline or as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         typescript_query: Vec<QuerySourceOrPath>,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1261,7 +1261,7 @@ mod cli {
 
             impl LanguageScopes {
                 /// Finds the first language field set, if any, and compiles the `QuerySourceOrPath`'s into a list of `LanguageScoper`'s.
-                pub(super) fn compile_querie_sources_to_scopes(self) -> Result<Option<crate::ScoperList>, ProgramError> {
+                pub(super) fn compile_query_sources_to_scopes(self) -> Result<Option<crate::ScoperList>, ProgramError> {
                     assert_exclusive_lang_scope(&[
                         $(self.$lang_flag.is_some(),)+
                     ]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -952,6 +952,7 @@ mod cli {
     use clap::builder::ArgPredicate;
     use clap::{ArgAction, Command, CommandFactory, Parser};
     use clap_complete::{generate, Generator, Shell};
+    use log::info;
     use srgn::scoping::langs::{
         c, csharp, go, hcl, python, rust, typescript, LanguageScoper, QuerySource,
     };
@@ -1347,15 +1348,21 @@ mod cli {
         {
             Ok(mut file) => {
                 info!(
-                    "Query points to a valid file at '{}', will use its contents.",
-                    file.path()
+                    "Query refers to a valid file at '{}', will use its contents.",
+                    query_or_path.as_str()
                 );
                 let mut s = String::new();
                 file.read_to_string(&mut s)?;
                 Ok(QuerySource::from(s))
             }
             Err(err) => match err.kind() {
-                io::ErrorKind::NotFound => Ok(QuerySource::from(query_or_path.0)),
+                io::ErrorKind::NotFound => {
+                    info!(
+                        "Query doesn't refer to a valid file at '{}', contents will by compiled as a TSQuery.",
+                        query_or_path.as_str()
+                    );
+                    Ok(QuerySource::from(query_or_path.0))
+                }
                 _ => Err(err),
             },
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1363,7 +1363,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment)]
         c: Vec<c::PreparedQuery>,
 
-        /// Scope C code using a custom tree-sitter query.
+        /// Scope C code using a custom tree-sitter query. The query can be given inline or
+        /// if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         c_query: Vec<QuerySourceOrPath>,
     }
@@ -1375,7 +1376,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment, visible_alias = "cs")]
         csharp: Vec<csharp::PreparedQuery>,
 
-        /// Scope C# code using a custom tree-sitter query.
+        /// Scope C# code using a custom tree-sitter query. The query can be given inline or
+        /// if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         csharp_query: Vec<QuerySourceOrPath>,
     }
@@ -1390,6 +1392,7 @@ mod cli {
 
         #[allow(clippy::doc_markdown)] // CamelCase detected as 'needs backticks'
         /// Scope HashiCorp Configuration Language code using a custom tree-sitter query.
+        /// The query can be given inline or if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         hcl_query: Vec<QuerySourceOrPath>,
     }
@@ -1401,7 +1404,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment)]
         go: Vec<go::PreparedQuery>,
 
-        /// Scope Go code using a custom tree-sitter query.
+        /// Scope Go code using a custom tree-sitter query. The query can be given inline or
+        /// if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         go_query: Vec<QuerySourceOrPath>,
     }
@@ -1413,7 +1417,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment, visible_alias = "py")]
         python: Vec<python::PreparedQuery>,
 
-        /// Scope Python code using a custom tree-sitter query.
+        /// Scope Python code using a custom tree-sitter query. The query can be given
+        /// inline or if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         python_query: Vec<QuerySourceOrPath>,
     }
@@ -1425,7 +1430,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment, visible_alias = "rs")]
         rust: Vec<rust::PreparedQuery>,
 
-        /// Scope Rust code using a custom tree-sitter query.
+        /// Scope Rust code using a custom tree-sitter query. The query can be given inline
+        /// or if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         rust_query: Vec<QuerySourceOrPath>,
     }
@@ -1437,7 +1443,8 @@ mod cli {
         #[arg(long, env, verbatim_doc_comment, visible_alias = "ts")]
         typescript: Vec<typescript::PreparedQuery>,
 
-        /// Scope TypeScript code using a custom tree-sitter query.
+        /// Scope TypeScript code using a custom tree-sitter query. The query can be given
+        /// inline or if as a path to a file containing a query.
         #[arg(long, env, verbatim_doc_comment, value_name = TREE_SITTER_QUERY_VALUE_OR_FILENAME)]
         typescript_query: Vec<QuerySourceOrPath>,
     }

--- a/src/scoping/langs.rs
+++ b/src/scoping/langs.rs
@@ -49,7 +49,7 @@ impl CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`] variant for when this method errors.
-    fn from_raw_query(lang: &TSLanguage, query: &RawQuery) -> Result<Self, TSQueryError> {
+    fn from_source(lang: &TSLanguage, query: &QuerySource) -> Result<Self, TSQueryError> {
         Self::from_str(lang, &query.0)
     }
 
@@ -92,13 +92,13 @@ impl CompiledQuery {
     }
 }
 
-/// A query over a language, for scoping.
+/// An uncompiled source for a query over a language, for scoping.
 ///
 /// Parts hit by the query are [`In`] scope, parts not hit are [`Out`] of scope.
 #[derive(Clone, Debug)]
-pub struct RawQuery(pub Cow<'static, str>);
+pub struct QuerySource(pub Cow<'static, str>);
 
-impl From<String> for RawQuery {
+impl From<String> for QuerySource {
     fn from(s: String) -> Self {
         Self(s.into())
     }

--- a/src/scoping/langs/c.rs
+++ b/src/scoping/langs/c.rs
@@ -2,14 +2,14 @@ use std::fmt::Debug;
 
 use clap::ValueEnum;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 
 /// A compiled query for the C language.
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the C language
@@ -17,8 +17,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError) variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_c::LANGUAGE.into(), &query)?;
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_c::LANGUAGE.into(), &query)?;
         Ok(Self(q))
     }
 }

--- a/src/scoping/langs/csharp.rs
+++ b/src/scoping/langs/csharp.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -11,7 +11,7 @@ use crate::scoping::langs::IGNORE;
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the C# language.
@@ -19,8 +19,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_c_sharp::LANGUAGE.into(), &query)
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_c_sharp::LANGUAGE.into(), &query)
             .expect("syntax of prepared queries is validated by tests");
         Ok(Self(q))
     }

--- a/src/scoping/langs/go.rs
+++ b/src/scoping/langs/go.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path};
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -12,7 +12,7 @@ use crate::scoping::langs::IGNORE;
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the Go language.
@@ -20,8 +20,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_go::LANGUAGE.into(), &query)?;
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_go::LANGUAGE.into(), &query)?;
         Ok(Self(q))
     }
 }

--- a/src/scoping/langs/hcl.rs
+++ b/src/scoping/langs/hcl.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{tree_sitter_hcl, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{tree_sitter_hcl, LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -11,7 +11,7 @@ use crate::scoping::langs::IGNORE;
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the Hashicorp Configuration language.
@@ -19,8 +19,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_hcl::language(), &query)?;
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_hcl::language(), &query)?;
         Ok(Self(q))
     }
 }

--- a/src/scoping/langs/python.rs
+++ b/src/scoping/langs/python.rs
@@ -3,14 +3,14 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Find, LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 use crate::scoping::langs::IGNORE;
 
 /// A compiled query for the Python language.
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the Python language.
@@ -18,8 +18,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_python::LANGUAGE.into(), &query)?;
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_python::LANGUAGE.into(), &query)?;
         Ok(Self(q))
     }
 }

--- a/src/scoping/langs/rust.rs
+++ b/src/scoping/langs/rust.rs
@@ -3,13 +3,13 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError, IGNORE};
+use super::{Find, LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError, IGNORE};
 
 /// A compiled query for the Rust language.
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the Rust language.
@@ -17,8 +17,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError) variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(&tree_sitter_rust::LANGUAGE.into(), &query)?;
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(&tree_sitter_rust::LANGUAGE.into(), &query)?;
         Ok(Self(q))
     }
 }

--- a/src/scoping/langs/typescript.rs
+++ b/src/scoping/langs/typescript.rs
@@ -2,13 +2,13 @@ use std::fmt::Debug;
 
 use clap::ValueEnum;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Find, LanguageScoper, QuerySource, TSLanguage, TSQuery, TSQueryError};
 
 /// A compiled query for the TypeScript language.
 #[derive(Debug)]
 pub struct CompiledQuery(super::CompiledQuery);
 
-impl TryFrom<RawQuery> for CompiledQuery {
+impl TryFrom<QuerySource> for CompiledQuery {
     type Error = TSQueryError;
 
     /// Create a new compiled query for the TypeScript language.
@@ -16,8 +16,8 @@ impl TryFrom<RawQuery> for CompiledQuery {
     /// # Errors
     ///
     /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
-    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
-        let q = super::CompiledQuery::from_raw_query(
+    fn try_from(query: QuerySource) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_source(
             &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             &query,
         )?;


### PR DESCRIPTION
Relates to #143 

@alexpovel I've added a proof of concept to this PR.
The most logical place to add the file check and read is to the `struct CustomRustQuery`.
If so the `QueryError` needs to be wrapped in a compound `Error` that can report 
`io::Error`'s along with the parsing errors `QueryError` is now designed to report.

What do you think? 