### PR TITLE
Rename `Language` to `CompiledQuery`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,22 +80,26 @@
 //! types, which are [`LanguageScoper`]s. Those may be used as, for example:
 //!
 //! ```rust
+//! use srgn::scoping::langs::{
+//!     python::{CompiledQuery, PreparedQuery},
+//!     RawQuery
+//! };
 //! use srgn::scoping::view::ScopedViewBuilder;
-//! use srgn::scoping::langs::CodeQuery as CQ;
-//! use srgn::scoping::langs::python::{Python, PreparedPythonQuery};
 //!
 //! let input = "def foo(bar: int) -> int: return bar + 1  # Do a thing";
-//!
-//! let lang = Python::new(CQ::Prepared(PreparedPythonQuery::Comments));
+//! let query = CompiledQuery::from(PreparedQuery::Comments);
 //!
 //! let mut builder = ScopedViewBuilder::new(input);
-//! builder.explode(&lang);
+//! builder.explode(&query);
 //!
 //! let mut view = builder.build();
 //! view.delete();
 //!
 //! // Comment gone, *however* trailing whitespace remains.
-//! assert_eq!(view.to_string(), "def foo(bar: int) -> int: return bar + 1  ");
+//! assert_eq!(
+//!     view.to_string(),
+//!     "def foo(bar: int) -> int: return bar + 1  "
+//! );
 //! ```
 //!
 //! ## Applying an action (associated function)

--- a/src/scoping/langs/mod.rs
+++ b/src/scoping/langs/mod.rs
@@ -1,9 +1,9 @@
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::borrow::Cow;
 
 use log::{debug, info, trace};
-pub use tree_sitter::{
+use tree_sitter::{
     Language as TSLanguage, Parser as TSParser, Query as TSQuery, QueryCursor as TSQueryCursor,
+    QueryError as TSQueryError,
 };
 
 use super::scope::RangesWithContext;
@@ -32,33 +32,33 @@ mod tree_sitter_hcl;
 /// TypeScript.
 pub mod typescript;
 
-/// Represents a (programming) language.
+/// Represents query compiled for a (programming) language L.
 #[derive(Debug)]
-pub struct Language<Q> {
+struct CompiledQuery {
     /// The *positive* query: it will be run against input and its results used for
     /// scoping.
     positive_query: TSQuery,
     /// The *negative* query: if present (if [`IGNORE`] is present) will be run and
     /// *subtracted* from the positive query.
     negative_query: Option<TSQuery>,
-    /// We are generic over this to allow languages to be their own type.
-    ///
-    /// We only store constructed [`TSQuery`]s as those are actually actionable and
-    /// references to them are required. However, [`TSQuery`]s are neither [`Clone`] nor
-    /// type-safe (a [`TSQuery`] is *associated* with a [`TSLanguage`], but that's not
-    /// enforced at the type level: a query constructed for Python could accidentally be
-    /// passed to Go etc.), so use this field to be more type-safe.
-    _marker: PhantomData<Q>,
 }
 
-impl<Q> Language<Q>
-where
-    Q: Into<TSQuery> + Clone,
-{
-    /// Create a new language with the given associated query over it.
-    #[allow(clippy::needless_pass_by_value)] // TODO: refactor later
-    pub fn new(query: Q) -> Self {
-        let positive_query = query.clone().into();
+impl CompiledQuery {
+    /// Create a new `CompiledQuery` from a `RawQuery`.
+    ///
+    /// # Errors
+    ///
+    /// See the concrete type of the [`TSQueryError`] variant for when this method errors.
+    fn from_raw_query(lang: &TSLanguage, query: &RawQuery) -> Result<Self, TSQueryError> {
+        Self::from_str(lang, &query.0)
+    }
+
+    fn from_prepared_query(lang: &TSLanguage, query: &str) -> Self {
+        Self::from_str(lang, query).expect("syntax of prepared queries is validated by tests")
+    }
+
+    fn from_str(lang: &TSLanguage, query: &str) -> Result<Self, TSQueryError> {
+        let positive_query = TSQuery::new(lang, query)?;
 
         let is_ignored = |name: &str| name.starts_with(IGNORE);
         let has_ignored_captures = positive_query
@@ -66,59 +66,41 @@ where
             .iter()
             .any(|name| is_ignored(name));
 
-        let negative_query = has_ignored_captures.then(|| {
-            let mut query = query.clone().into();
-            let acknowledged_captures = query
-                .capture_names()
-                .iter()
-                .filter(|name| !is_ignored(name))
-                .map(|s| String::from(*s))
-                .collect::<Vec<_>>();
+        let negative_query = has_ignored_captures
+            .then(|| {
+                let mut query = TSQuery::new(lang, query)?;
+                let acknowledged_captures = query
+                    .capture_names()
+                    .iter()
+                    .filter(|name| !is_ignored(name))
+                    .map(|s| String::from(*s))
+                    .collect::<Vec<_>>();
 
-            for name in acknowledged_captures {
-                trace!("Disabling capture for: {:?}", name);
-                query.disable_capture(&name);
-            }
+                for name in acknowledged_captures {
+                    trace!("Disabling capture for: {:?}", name);
+                    query.disable_capture(&name);
+                }
 
-            query
-        });
+                Ok(query)
+            })
+            .transpose()?;
 
-        Self {
+        Ok(Self {
             positive_query,
             negative_query,
-            _marker: PhantomData,
-        }
+        })
     }
 }
 
 /// A query over a language, for scoping.
 ///
 /// Parts hit by the query are [`In`] scope, parts not hit are [`Out`] of scope.
-#[derive(Debug, Clone)]
-pub enum CodeQuery<C, P>
-where
-    C: FromStr + Into<TSQuery>,
-    P: Into<TSQuery>,
-{
-    /// A custom, user-defined query.
-    Custom(C),
-    /// A prepared query.
-    ///
-    /// Availability depends on the language, respective languages features, and
-    /// implementation in this crate.
-    Prepared(P),
-}
+#[derive(Clone, Debug)]
+pub struct RawQuery(pub Cow<'static, str>);
 
-impl<C, P> From<CodeQuery<C, P>> for TSQuery
-where
-    C: FromStr + Into<Self>,
-    P: Into<Self>,
-{
-    fn from(value: CodeQuery<C, P>) -> Self {
-        match value {
-            CodeQuery::Custom(query) => query.into(),
-            CodeQuery::Prepared(query) => query.into(),
-        }
+impl From<String> for RawQuery {
+    fn from(s: String) -> Self {
+        Self(s.into())
     }
 }
 

--- a/src/scoping/langs/python.rs
+++ b/src/scoping/langs/python.rs
@@ -1,21 +1,41 @@
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use clap::ValueEnum;
 use const_format::formatcp;
-use tree_sitter::QueryError;
 
-use super::{CodeQuery, Find, Language, LanguageScoper, TSLanguage, TSQuery};
+use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::scoping::langs::IGNORE;
 
-/// The Python language.
-pub type Python = Language<PythonQuery>;
-/// A query for Python.
-pub type PythonQuery = CodeQuery<CustomPythonQuery, PreparedPythonQuery>;
+/// A compiled query for the Python language.
+#[derive(Debug)]
+pub struct CompiledQuery(super::CompiledQuery);
+
+impl TryFrom<RawQuery> for CompiledQuery {
+    type Error = TSQueryError;
+
+    /// Create a new compiled query for the Python language.
+    ///
+    /// # Errors
+    ///
+    /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError)variant for when this method errors.
+    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_raw_query(&tree_sitter_python::LANGUAGE.into(), &query)?;
+        Ok(Self(q))
+    }
+}
+
+impl From<PreparedQuery> for CompiledQuery {
+    fn from(query: PreparedQuery) -> Self {
+        Self(super::CompiledQuery::from_prepared_query(
+            &tree_sitter_python::LANGUAGE.into(),
+            query.as_str(),
+        ))
+    }
+}
 
 /// Prepared tree-sitter queries for Python.
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum PreparedPythonQuery {
+pub enum PreparedQuery {
     /// Comments.
     Comments,
     /// Strings (raw, byte, f-strings; interpolation not included).
@@ -56,164 +76,134 @@ pub enum PreparedPythonQuery {
     Identifiers,
 }
 
-impl From<PreparedPythonQuery> for TSQuery {
+impl PreparedQuery {
     #[allow(clippy::too_many_lines)]
-    fn from(value: PreparedPythonQuery) -> Self {
-        Self::new(
-            &Python::lang(),
-            match value {
-                PreparedPythonQuery::Comments => "(comment) @comment",
-                PreparedPythonQuery::Strings => "(string_content) @string",
-                PreparedPythonQuery::Imports => {
-                    r"[
-                        (import_statement
-                                name: (dotted_name) @dn)
-                        (import_from_statement
-                                module_name: (dotted_name) @dn)
-                        (import_from_statement
-                                module_name: (dotted_name) @dn
-                                    (wildcard_import))
-                        (import_statement(
-                            aliased_import
-                                name: (dotted_name) @dn))
-                        (import_from_statement
-                            module_name: (relative_import) @ri)
-                    ]"
-                }
-                PreparedPythonQuery::DocStrings => {
-                    // Triple-quotes are also used for multi-line strings. So look only
-                    // for stand-alone expressions, which are not part of some variable
-                    // assignment.
-                    formatcp!(
-                        "
-                        (
-                            (expression_statement
-                                (string
-                                    (string_start) @{0}
-                                    (string_content) @string
-                                    (#match? @{0} \"\\^\\\"\\\"\\\"\")
-                                )
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Comments => "(comment) @comment",
+            Self::Strings => "(string_content) @string",
+            Self::Imports => {
+                r"[
+                    (import_statement
+                            name: (dotted_name) @dn)
+                    (import_from_statement
+                            module_name: (dotted_name) @dn)
+                    (import_from_statement
+                            module_name: (dotted_name) @dn
+                                (wildcard_import))
+                    (import_statement(
+                        aliased_import
+                            name: (dotted_name) @dn))
+                    (import_from_statement
+                        module_name: (relative_import) @ri)
+                ]"
+            }
+            Self::DocStrings => {
+                // Triple-quotes are also used for multi-line strings. So look only
+                // for stand-alone expressions, which are not part of some variable
+                // assignment.
+                formatcp!(
+                    "
+                    (
+                        (expression_statement
+                            (string
+                                (string_start) @{0}
+                                (string_content) @string
+                                (#match? @{0} \"\\^\\\"\\\"\\\"\")
                             )
                         )
-                        ",
-                        IGNORE
                     )
-                }
-                PreparedPythonQuery::FunctionNames => {
-                    r"
-                    (function_definition
-                        name: (identifier) @function-name
+                    ",
+                    IGNORE
+                )
+            }
+            Self::FunctionNames => {
+                r"
+                (function_definition
+                    name: (identifier) @function-name
+                )
+                "
+            }
+            Self::FunctionCalls => {
+                r"
+                (call
+                    function: (identifier) @function-name
+                )
+                "
+            }
+            Self::Class => "(class_definition) @class",
+            Self::Def => "(function_definition) @def",
+            Self::AsyncDef => r#"((function_definition) @def (#match? @def "^async "))"#,
+            Self::Methods => {
+                r"
+                (class_definition
+                    body: (block
+                        [
+                            (function_definition) @method
+                            (decorated_definition definition: (function_definition)) @method
+                        ]
                     )
+                )
+                "
+            }
+            Self::ClassMethods => {
+                formatcp!(
                     "
-                }
-                PreparedPythonQuery::FunctionCalls => {
-                    r"
-                    (call
-                        function: (identifier) @function-name
-                    )
-                    "
-                }
-                PreparedPythonQuery::Class => "(class_definition) @class",
-                PreparedPythonQuery::Def => "(function_definition) @def",
-                PreparedPythonQuery::AsyncDef => {
-                    r#"((function_definition) @def (#match? @def "^async "))"#
-                }
-                PreparedPythonQuery::Methods => {
-                    r"
                     (class_definition
                         body: (block
-                            [
-                                (function_definition) @method
-                                (decorated_definition definition: (function_definition)) @method
-                            ]
+                            (decorated_definition
+                                (decorator (identifier) @{0})
+                                definition: (function_definition) @method
+                                (#eq? @{0} \"classmethod\")
+                            )
                         )
-                    )
+                    )",
+                    IGNORE
+                )
+            }
+            Self::StaticMethods => {
+                formatcp!(
                     "
-                }
-                PreparedPythonQuery::ClassMethods => {
-                    formatcp!(
-                        "
-                        (class_definition
-                            body: (block
-                                (decorated_definition
-                                    (decorator (identifier) @{0})
-                                    definition: (function_definition) @method
-                                    (#eq? @{0} \"classmethod\")
-                                )
+                    (class_definition
+                        body: (block
+                            (decorated_definition
+                                (decorator (identifier) @{0})
+                                definition: (function_definition) @method
+                                (#eq? @{0} \"staticmethod\")
                             )
-                        )",
-                        IGNORE
-                    )
-                }
-                PreparedPythonQuery::StaticMethods => {
-                    formatcp!(
-                        "
-                        (class_definition
-                            body: (block
-                                (decorated_definition
-                                    (decorator (identifier) @{0})
-                                    definition: (function_definition) @method
-                                    (#eq? @{0} \"staticmethod\")
-                                )
-                            )
-                        )",
-                        IGNORE
-                    )
-                }
-                PreparedPythonQuery::With => "(with_statement) @with",
-                PreparedPythonQuery::Try => "(try_statement) @try",
-                PreparedPythonQuery::Lambda => "(lambda) @lambda",
-                PreparedPythonQuery::Globals => {
-                    "(module (expression_statement (assignment left: (identifier) @global)))"
-                }
-                PreparedPythonQuery::VariableIdentifiers => {
-                    "(assignment left: (identifier) @identifier)"
-                }
-                PreparedPythonQuery::Types => "(type) @type",
-                PreparedPythonQuery::Identifiers => "(identifier) @identifier",
-            },
-        )
-        .expect("Prepared queries to be valid")
-    }
-}
-
-/// A custom tree-sitter query for Python.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CustomPythonQuery(String);
-
-impl FromStr for CustomPythonQuery {
-    type Err = QueryError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match TSQuery::new(&Python::lang(), s) {
-            Ok(_) => Ok(Self(s.to_string())),
-            Err(e) => Err(e),
+                        )
+                    )",
+                    IGNORE
+                )
+            }
+            Self::With => "(with_statement) @with",
+            Self::Try => "(try_statement) @try",
+            Self::Lambda => "(lambda) @lambda",
+            Self::Globals => {
+                "(module (expression_statement (assignment left: (identifier) @global)))"
+            }
+            Self::VariableIdentifiers => "(assignment left: (identifier) @identifier)",
+            Self::Types => "(type) @type",
+            Self::Identifiers => "(identifier) @identifier",
         }
     }
 }
 
-impl From<CustomPythonQuery> for TSQuery {
-    fn from(value: CustomPythonQuery) -> Self {
-        Self::new(&Python::lang(), &value.0)
-            .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl LanguageScoper for Python {
+impl LanguageScoper for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_python::LANGUAGE.into()
     }
 
     fn pos_query(&self) -> &TSQuery {
-        &self.positive_query
+        &self.0.positive_query
     }
 
     fn neg_query(&self) -> Option<&TSQuery> {
-        self.negative_query.as_ref()
+        self.0.negative_query.as_ref()
     }
 }
 
-impl Find for Python {
+impl Find for CompiledQuery {
     fn extensions(&self) -> &'static [&'static str] {
         &["py"]
     }

--- a/src/scoping/langs/rust.rs
+++ b/src/scoping/langs/rust.rs
@@ -1,20 +1,40 @@
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use clap::ValueEnum;
 use const_format::formatcp;
-use tree_sitter::QueryError;
 
-use super::{CodeQuery, Find, Language, LanguageScoper, TSLanguage, TSQuery, IGNORE};
+use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError, IGNORE};
 
-/// The Rust language.
-pub type Rust = Language<RustQuery>;
-/// A query for Rust.
-pub type RustQuery = CodeQuery<CustomRustQuery, PreparedRustQuery>;
+/// A compiled query for the Rust language.
+#[derive(Debug)]
+pub struct CompiledQuery(super::CompiledQuery);
+
+impl TryFrom<RawQuery> for CompiledQuery {
+    type Error = TSQueryError;
+
+    /// Create a new compiled query for the Rust language.
+    ///
+    /// # Errors
+    ///
+    /// See the concrete type of the [`TSQueryError`](tree_sitter::QueryError) variant for when this method errors.
+    fn try_from(query: RawQuery) -> Result<Self, Self::Error> {
+        let q = super::CompiledQuery::from_raw_query(&tree_sitter_rust::LANGUAGE.into(), &query)?;
+        Ok(Self(q))
+    }
+}
+
+impl From<PreparedQuery> for CompiledQuery {
+    fn from(query: PreparedQuery) -> Self {
+        Self(super::CompiledQuery::from_prepared_query(
+            &tree_sitter_rust::LANGUAGE.into(),
+            query.as_str(),
+        ))
+    }
+}
 
 /// Prepared tree-sitter queries for Rust.
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum PreparedRustQuery {
+pub enum PreparedQuery {
     /// Comments (line and block styles; excluding doc comments; comment chars incl.).
     Comments,
     /// Doc comments (comment chars included).
@@ -104,281 +124,255 @@ pub enum PreparedRustQuery {
     Unsafe,
 }
 
-impl From<PreparedRustQuery> for TSQuery {
+impl PreparedQuery {
     #[allow(clippy::too_many_lines)]
-    fn from(value: PreparedRustQuery) -> Self {
-        Self::new(
-            &Rust::lang(),
-            match value {
-                PreparedRustQuery::Comments => {
-                    r#"
-                    [
-                        (line_comment)+ @line
-                        (block_comment)
-                        (#not-match? @line "^///")
-                    ]
-                    @comment
-                    "#
-                }
-                PreparedRustQuery::DocComments => {
-                    r#"
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Comments => {
+                r#"
+                [
+                    (line_comment)+ @line
+                    (block_comment)
+                    (#not-match? @line "^///")
+                ]
+                @comment
+                "#
+            }
+            Self::DocComments => {
+                r#"
+                (
+                    (line_comment)+ @line
+                    (#match? @line "^//(/|!)")
+                )
+                "#
+            }
+            Self::Uses => {
+                // Match any (wildcard `_`) `argument`, which includes:
+                //
+                // - `scoped_identifier`
+                // - `scoped_use_list`
+                // - `use_wildcard`
+                // - `use_as_clause`
+                //
+                // all at once.
+                r"
+                [
+                    (use_declaration
+                        argument: (_) @use
+                    )
+                ]
+                "
+            }
+            Self::Strings => "(string_content) @string",
+            Self::Attribute => "(attribute) @attribute",
+            Self::Struct => "(struct_item) @struct_item",
+            Self::PrivStruct => {
+                r"(struct_item
+                    .
+                    name: (type_identifier)
+                ) @struct_item_without_visibility_modifier"
+            }
+            Self::PubStruct => {
+                r#"(struct_item
+                    (visibility_modifier) @vis
+                    (#eq? @vis "pub")
+                ) @struct_item"#
+            }
+            Self::PubCrateStruct => {
+                r"(struct_item
+                    (visibility_modifier (crate))
+                ) @struct_item"
+            }
+            Self::PubSelfStruct => {
+                r"(struct_item
+                    (visibility_modifier (self))
+                ) @struct_item"
+            }
+            Self::PubSuperStruct => {
+                r"(struct_item
+                    (visibility_modifier (super))
+                ) @struct_item"
+            }
+            Self::Enum => "(enum_item) @enum_item",
+            Self::PrivEnum => {
+                r"(enum_item
+                    .
+                    name: (type_identifier)
+                ) @enum_item_without_visibility_modifier"
+            }
+            Self::PubEnum => {
+                r#"(enum_item
+                    (visibility_modifier) @vis
+                    (#eq? @vis "pub")
+                ) @enum_item"#
+            }
+            Self::PubCrateEnum => {
+                r"(enum_item
+                    (visibility_modifier (crate))
+                ) @enum_item"
+            }
+            Self::PubSelfEnum => {
+                r"(enum_item
+                    (visibility_modifier (self))
+                ) @enum_item"
+            }
+            Self::PubSuperEnum => {
+                r"(enum_item
+                    (visibility_modifier (super))
+                ) @enum_item"
+            }
+            Self::EnumVariant => "(enum_variant) @enum_variant",
+            Self::Fn => "(function_item) @function_item",
+            Self::ImplFn => {
+                r"(impl_item
+                    body: (_ (function_item) @function)
+                )"
+            }
+            Self::PrivFn => {
+                r"(function_item
+                    .
+                    name: (identifier)
+                ) @function_item_without_visibility_modifier"
+            }
+            Self::PubFn => {
+                r#"(function_item
+                    (visibility_modifier) @vis
+                    (#eq? @vis "pub")
+                ) @function_item"#
+            }
+            Self::PubCrateFn => {
+                r"(function_item
+                    (visibility_modifier (crate))
+                ) @function_item"
+            }
+            Self::PubSelfFn => {
+                r"(function_item
+                    (visibility_modifier (self))
+                ) @function_item"
+            }
+            Self::PubSuperFn => {
+                r"(function_item
+                    (visibility_modifier (super))
+                ) @function_item"
+            }
+            Self::ConstFn => {
+                r#"(function_item
+                    (function_modifiers) @funcmods
+                    (#match? @funcmods "const")
+                ) @function_item"#
+            }
+            Self::AsyncFn => {
+                r#"(function_item
+                    (function_modifiers) @funcmods
+                    (#match? @funcmods "async")
+                ) @function_item"#
+            }
+            Self::UnsafeFn => {
+                r#"(function_item
+                    (function_modifiers) @funcmods
+                    (#match? @funcmods "unsafe")
+                ) @function_item"#
+            }
+            Self::ExternFn => {
+                r"(function_item
+                    (function_modifiers (extern_modifier))
+                ) @extern_function"
+            }
+            Self::TestFn => {
+                // Any attribute which matches aka contains `test`, preceded or
+                // followed by more attributes, eventually preceded by a function.
+                // The anchors of `.` ensure nothing but the items we're after occur
+                // in between.
+                formatcp!(
+                    "
                     (
-                        (line_comment)+ @line
-                        (#match? @line "^//(/|!)")
-                    )
-                    "#
-                }
-                PreparedRustQuery::Uses => {
-                    // Match any (wildcard `_`) `argument`, which includes:
-                    //
-                    // - `scoped_identifier`
-                    // - `scoped_use_list`
-                    // - `use_wildcard`
-                    // - `use_as_clause`
-                    //
-                    // all at once.
-                    r"
+                        (attribute_item)*
+                        .
+                        (attribute_item (attribute) @{0}.attr (#match? @{0}.attr \"test\"))
+                        .
+                        (attribute_item)*
+                        .
+                        (function_item) @func
+                    )",
+                    IGNORE
+                )
+            }
+            Self::Trait => "(trait_item) @trait_item",
+            Self::Impl => "(impl_item) @impl_item",
+            Self::ImplType => {
+                r"(impl_item
+                    type: (_)
+                    !trait
+                ) @impl_item"
+            }
+            Self::ImplTrait => {
+                r"(impl_item
+                    trait: (_)
+                    .
+                    type: (_)
+                ) @impl_item"
+            }
+            Self::Mod => "(mod_item) @mod_item",
+            Self::ModTests => {
+                r#"(mod_item
+                    name: (identifier) @mod_name
+                    (#eq? @mod_name "tests")
+                ) @mod_tests
+                "#
+            }
+            Self::TypeDef => {
+                r"
+                [
+                    (struct_item)
+                    (enum_item)
+                    (union_item)
+                ]
+                @typedef
+                "
+            }
+            Self::Identifier => "(identifier) @identifier",
+            Self::TypeIdentifier => "(type_identifier) @identifier",
+            Self::Closure => "(closure_expression) @closure",
+            Self::Unsafe => {
+                r#"
                     [
-                        (use_declaration
-                            argument: (_) @use
-                        )
-                    ]
-                    "
-                }
-                PreparedRustQuery::Strings => "(string_content) @string",
-                PreparedRustQuery::Attribute => "(attribute) @attribute",
-                PreparedRustQuery::Struct => "(struct_item) @struct_item",
-                PreparedRustQuery::PrivStruct => {
-                    r"(struct_item
-                        .
-                        name: (type_identifier)
-                    ) @struct_item_without_visibility_modifier"
-                }
-                PreparedRustQuery::PubStruct => {
-                    r#"(struct_item
-                        (visibility_modifier) @vis
-                        (#eq? @vis "pub")
-                    ) @struct_item"#
-                }
-                PreparedRustQuery::PubCrateStruct => {
-                    r"(struct_item
-                        (visibility_modifier (crate))
-                    ) @struct_item"
-                }
-                PreparedRustQuery::PubSelfStruct => {
-                    r"(struct_item
-                        (visibility_modifier (self))
-                    ) @struct_item"
-                }
-                PreparedRustQuery::PubSuperStruct => {
-                    r"(struct_item
-                        (visibility_modifier (super))
-                    ) @struct_item"
-                }
-                PreparedRustQuery::Enum => "(enum_item) @enum_item",
-                PreparedRustQuery::PrivEnum => {
-                    r"(enum_item
-                        .
-                        name: (type_identifier)
-                    ) @enum_item_without_visibility_modifier"
-                }
-                PreparedRustQuery::PubEnum => {
-                    r#"(enum_item
-                        (visibility_modifier) @vis
-                        (#eq? @vis "pub")
-                    ) @enum_item"#
-                }
-                PreparedRustQuery::PubCrateEnum => {
-                    r"(enum_item
-                        (visibility_modifier (crate))
-                    ) @enum_item"
-                }
-                PreparedRustQuery::PubSelfEnum => {
-                    r"(enum_item
-                        (visibility_modifier (self))
-                    ) @enum_item"
-                }
-                PreparedRustQuery::PubSuperEnum => {
-                    r"(enum_item
-                        (visibility_modifier (super))
-                    ) @enum_item"
-                }
-                PreparedRustQuery::EnumVariant => "(enum_variant) @enum_variant",
-                PreparedRustQuery::Fn => "(function_item) @function_item",
-                PreparedRustQuery::ImplFn => {
-                    r"(impl_item
-                        body: (_ (function_item) @function)
-                    )"
-                }
-                PreparedRustQuery::PrivFn => {
-                    r"(function_item
-                        .
-                        name: (identifier)
-                    ) @function_item_without_visibility_modifier"
-                }
-                PreparedRustQuery::PubFn => {
-                    r#"(function_item
-                        (visibility_modifier) @vis
-                        (#eq? @vis "pub")
-                    ) @function_item"#
-                }
-                PreparedRustQuery::PubCrateFn => {
-                    r"(function_item
-                        (visibility_modifier (crate))
-                    ) @function_item"
-                }
-                PreparedRustQuery::PubSelfFn => {
-                    r"(function_item
-                        (visibility_modifier (self))
-                    ) @function_item"
-                }
-                PreparedRustQuery::PubSuperFn => {
-                    r"(function_item
-                        (visibility_modifier (super))
-                    ) @function_item"
-                }
-                PreparedRustQuery::ConstFn => {
-                    r#"(function_item
-                        (function_modifiers) @funcmods
-                        (#match? @funcmods "const")
-                    ) @function_item"#
-                }
-                PreparedRustQuery::AsyncFn => {
-                    r#"(function_item
-                        (function_modifiers) @funcmods
-                        (#match? @funcmods "async")
-                    ) @function_item"#
-                }
-                PreparedRustQuery::UnsafeFn => {
-                    r#"(function_item
-                        (function_modifiers) @funcmods
-                        (#match? @funcmods "unsafe")
-                    ) @function_item"#
-                }
-                PreparedRustQuery::ExternFn => {
-                    r"(function_item
-                        (function_modifiers (extern_modifier))
-                    ) @extern_function"
-                }
-                PreparedRustQuery::TestFn => {
-                    // Any attribute which matches aka contains `test`, preceded or
-                    // followed by more attributes, eventually preceded by a function.
-                    // The anchors of `.` ensure nothing but the items we're after occur
-                    // in between.
-                    formatcp!(
-                        "
                         (
-                            (attribute_item)*
-                            .
-                            (attribute_item (attribute) @{0}.attr (#match? @{0}.attr \"test\"))
-                            .
-                            (attribute_item)*
-                            .
-                            (function_item) @func
-                        )",
-                        IGNORE
-                    )
-                }
-                PreparedRustQuery::Trait => "(trait_item) @trait_item",
-                PreparedRustQuery::Impl => "(impl_item) @impl_item",
-                PreparedRustQuery::ImplType => {
-                    r"(impl_item
-                        type: (_)
-                        !trait
-                    ) @impl_item"
-                }
-                PreparedRustQuery::ImplTrait => {
-                    r"(impl_item
-                        trait: (_)
-                        .
-                        type: (_)
-                    ) @impl_item"
-                }
-                PreparedRustQuery::Mod => "(mod_item) @mod_item",
-                PreparedRustQuery::ModTests => {
-                    r#"(mod_item
-                        name: (identifier) @mod_name
-                        (#eq? @mod_name "tests")
-                    ) @mod_tests
-                    "#
-                }
-                PreparedRustQuery::TypeDef => {
-                    r"
-                    [
-                        (struct_item)
-                        (enum_item)
-                        (union_item)
-                    ]
-                    @typedef
-                    "
-                }
-                PreparedRustQuery::Identifier => "(identifier) @identifier",
-                PreparedRustQuery::TypeIdentifier => "(type_identifier) @identifier",
-                PreparedRustQuery::Closure => "(closure_expression) @closure",
-                PreparedRustQuery::Unsafe => {
-                    r#"
-                        [
-                            (
-                                (trait_item) @ti (#match? @ti "^unsafe")
-                            )
-                            (
-                                (impl_item) @ii (#match? @ii "^unsafe")
-                            )
-                            (function_item
-                                (function_modifiers) @funcmods
-                                (#match? @funcmods "unsafe")
-                            ) @function_item
-                            (function_signature_item
-                                (function_modifiers) @funcmods
-                                (#match? @funcmods "unsafe")
-                            ) @function_signature_item
-                            (unsafe_block) @block
-                        ] @unsafe
-                    "#
-                }
-            },
-        )
-        .expect("Prepared queries to be valid")
-    }
-}
-
-/// A custom tree-sitter query for Rust.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CustomRustQuery(String);
-
-impl FromStr for CustomRustQuery {
-    type Err = QueryError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match TSQuery::new(&Rust::lang(), s) {
-            Ok(_) => Ok(Self(s.to_string())),
-            Err(e) => Err(e),
+                            (trait_item) @ti (#match? @ti "^unsafe")
+                        )
+                        (
+                            (impl_item) @ii (#match? @ii "^unsafe")
+                        )
+                        (function_item
+                            (function_modifiers) @funcmods
+                            (#match? @funcmods "unsafe")
+                        ) @function_item
+                        (function_signature_item
+                            (function_modifiers) @funcmods
+                            (#match? @funcmods "unsafe")
+                        ) @function_signature_item
+                        (unsafe_block) @block
+                    ] @unsafe
+                "#
+            }
         }
     }
 }
 
-impl From<CustomRustQuery> for TSQuery {
-    fn from(value: CustomRustQuery) -> Self {
-        Self::new(&Rust::lang(), &value.0)
-            .expect("Valid query, as object cannot be constructed otherwise")
-    }
-}
-
-impl LanguageScoper for Rust {
+impl LanguageScoper for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_rust::LANGUAGE.into()
     }
 
     fn pos_query(&self) -> &TSQuery {
-        &self.positive_query
+        &self.0.positive_query
     }
 
     fn neg_query(&self) -> Option<&TSQuery> {
-        self.negative_query.as_ref()
+        self.0.negative_query.as_ref()
     }
 }
 
-impl Find for Rust {
+impl Find for CompiledQuery {
     fn extensions(&self) -> &'static [&'static str] {
         &["rs"]
     }

--- a/tests/langs/mod.rs
+++ b/tests/langs/mod.rs
@@ -2,14 +2,7 @@ use std::ops::Range;
 
 use rstest::rstest;
 use serde::{Deserialize, Serialize};
-use srgn::scoping::langs::c::{PreparedCQuery, C};
-use srgn::scoping::langs::csharp::{CSharp, PreparedCSharpQuery};
-use srgn::scoping::langs::go::{Go, PreparedGoQuery};
-use srgn::scoping::langs::hcl::{Hcl, PreparedHclQuery};
-use srgn::scoping::langs::python::{PreparedPythonQuery, Python};
-use srgn::scoping::langs::rust::{PreparedRustQuery, Rust};
-use srgn::scoping::langs::typescript::{PreparedTypeScriptQuery, TypeScript};
-use srgn::scoping::langs::{CodeQuery, LanguageScoper};
+use srgn::scoping::langs::{c, csharp, go, hcl, python, rust, typescript, LanguageScoper};
 use srgn::scoping::scope::Scope;
 use srgn::scoping::view::ScopedViewBuilder;
 
@@ -73,757 +66,757 @@ impl InScopeLinePart {
 #[case(
     "base.py_comments",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Comments)),
+    python::CompiledQuery::from(python::PreparedQuery::Comments),
 )]
 #[case(
     "base.py_strings",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Strings)),
+    python::CompiledQuery::from(python::PreparedQuery::Strings),
 )]
 #[case(
     "base.py_imports",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Imports)),
+    python::CompiledQuery::from(python::PreparedQuery::Imports),
 )]
 #[case(
     "base.py_docstrings",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::DocStrings)),
+    python::CompiledQuery::from(python::PreparedQuery::DocStrings),
 )]
 #[case(
     "base.py_function-names",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::FunctionNames)),
+    python::CompiledQuery::from(python::PreparedQuery::FunctionNames),
 )]
 #[case(
     "base.py_function-calls",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::FunctionCalls)),
+    python::CompiledQuery::from(python::PreparedQuery::FunctionCalls),
 )]
 #[case(
     "base.py_class",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Class)),
+    python::CompiledQuery::from(python::PreparedQuery::Class),
 )]
 #[case(
     "base.py_def",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Def)),
+    python::CompiledQuery::from(python::PreparedQuery::Def),
 )]
 #[case(
     "base.py_async-def",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::AsyncDef)),
+    python::CompiledQuery::from(python::PreparedQuery::AsyncDef),
 )]
 #[case(
     "base.py_methods",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Methods)),
+    python::CompiledQuery::from(python::PreparedQuery::Methods),
 )]
 #[case(
     "base.py_classmethods",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::ClassMethods)),
+    python::CompiledQuery::from(python::PreparedQuery::ClassMethods),
 )]
 #[case(
     "base.py_staticmethods",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::StaticMethods)),
+    python::CompiledQuery::from(python::PreparedQuery::StaticMethods),
 )]
 #[case(
     "base.py_with",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::With)),
+    python::CompiledQuery::from(python::PreparedQuery::With),
 )]
 #[case(
     "base.py_try",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Try)),
+    python::CompiledQuery::from(python::PreparedQuery::Try),
 )]
 #[case(
     "base.py_lambda",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Lambda)),
+    python::CompiledQuery::from(python::PreparedQuery::Lambda),
 )]
 #[case(
     "base.py_globals",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Globals)),
+    python::CompiledQuery::from(python::PreparedQuery::Globals),
 )]
 #[case(
     "base.py_variable_identifiers",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::VariableIdentifiers)),
+    python::CompiledQuery::from(python::PreparedQuery::VariableIdentifiers),
 )]
 #[case(
     "base.py_types",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Types)),
+    python::CompiledQuery::from(python::PreparedQuery::Types),
 )]
 #[case(
     "base.py_identifiers",
     include_str!("python/base.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Identifiers)),
+    python::CompiledQuery::from(python::PreparedQuery::Identifiers),
 )]
 #[case(
     "identifiers.py_identifiers",
     include_str!("python/identifiers.py"),
-    Python::new(CodeQuery::Prepared(PreparedPythonQuery::Identifiers)),
+    python::CompiledQuery::from(python::PreparedQuery::Identifiers),
 )]
 #[case(
     "base.ts_strings",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Strings)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Strings),
 )]
 #[case(
     "base.ts_comments",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Comments)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Comments),
 )]
 #[case(
     "base.ts_imports",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Imports)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Imports),
 )]
 #[case(
     "base.ts_function",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Function)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Function),
 )]
 #[case(
     "base.ts_async-function",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::AsyncFunction)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::AsyncFunction),
 )]
 #[case(
     "base.ts_sync-function",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::SyncFunction)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::SyncFunction),
 )]
 #[case(
     "base.ts_method",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Method)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Method),
 )]
 #[case(
     "base.ts_constructor",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Constructor)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Constructor),
 )]
 #[case(
     "base.ts_class",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Class)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Class),
 )]
 #[case(
     "base.ts_enum",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Enum)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Enum),
 )]
 #[case(
     "base.ts_interface",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Interface)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Interface),
 )]
 #[case(
     "base.ts_try-block",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::TryCatch)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::TryCatch),
 )]
 #[case(
     "base.ts_var_decl",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::VarDecl)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::VarDecl),
 )]
 #[case(
     "base.ts_let",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Let)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Let),
 )]
 #[case(
     "base.ts_const",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Const)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Const),
 )]
 #[case(
     "base.ts_var",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Var)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Var),
 )]
 #[case(
     "base.ts_type-params",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::TypeParams)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::TypeParams),
 )]
 #[case(
     "base.ts_type-alias",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::TypeAlias)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::TypeAlias),
 )]
 #[case(
     "base.ts_namespace",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Namespace)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Namespace),
 )]
 #[case(
     "base.ts_export",
     include_str!("typescript/base.ts"),
-    TypeScript::new(CodeQuery::Prepared(PreparedTypeScriptQuery::Export)),
+    typescript::CompiledQuery::from(typescript::PreparedQuery::Export),
 )]
 #[case(
     "base.rs_strings",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Strings)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Strings),
 )]
 #[case(
     "base.rs_comments",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Comments)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Comments),
 )]
 #[case(
     "base.rs_uses",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Uses)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Uses),
 )]
 #[case(
     "base.rs_doc-comments",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::DocComments)),
+    rust::CompiledQuery::from(rust::PreparedQuery::DocComments),
 )]
 #[case(
     "base.rs_attribute",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Attribute)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Attribute),
 )]
 #[case(
     "base.rs_struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Struct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Struct),
 )]
 #[case(
     "base.rs_pub-struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubStruct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubStruct),
 )]
 #[case(
     "base.rs_pub-priv-struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PrivStruct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PrivStruct),
 )]
 #[case(
     "base.rs_pub-crate-struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubCrateStruct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubCrateStruct),
 )]
 #[case(
     "base.rs_pub-self-struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSelfStruct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSelfStruct),
 )]
 #[case(
     "base.rs_pub-super-struct",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSuperStruct)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSuperStruct),
 )]
 #[case(
     "base.enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Enum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Enum),
 )]
 #[case(
     "base.rs_pub-priv-enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PrivEnum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PrivEnum),
 )]
 #[case(
     "base.rs_pub-enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubEnum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubEnum),
 )]
 #[case(
     "base.rs_pub-crate-enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubCrateEnum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubCrateEnum),
 )]
 #[case(
     "base.rs_pub-self-enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSelfEnum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSelfEnum),
 )]
 #[case(
     "base.rs_pub-super-enum",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSuperEnum)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSuperEnum),
 )]
 #[case(
     "base.rs_enum-variant",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::EnumVariant)),
+    rust::CompiledQuery::from(rust::PreparedQuery::EnumVariant),
 )]
 #[case(
     "base.rs_fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Fn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Fn),
 )]
 #[case(
     "base.rs_impl-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ImplFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ImplFn),
 )]
 #[case(
     "base.rs_pub-priv-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PrivFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PrivFn),
 )]
 #[case(
     "base.rs_pub-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubFn),
 )]
 #[case(
     "base.rs_pub-crate-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubCrateFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubCrateFn),
 )]
 #[case(
     "base.rs_pub-self-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSelfFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSelfFn),
 )]
 #[case(
     "base.rs_pub-super-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::PubSuperFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::PubSuperFn),
 )]
 #[case(
     "base.rs_const-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ConstFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ConstFn),
 )]
 #[case(
     "base.rs_async-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::AsyncFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::AsyncFn),
 )]
 #[case(
     "base.rs_unsafe-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::UnsafeFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::UnsafeFn),
 )]
 #[case(
     "base.rs_extern-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ExternFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ExternFn),
 )]
 #[case(
     "base.rs_test-fn",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::TestFn)),
+    rust::CompiledQuery::from(rust::PreparedQuery::TestFn),
 )]
 #[case(
     "base.rs_trait",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Trait)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Trait),
 )]
 #[case(
     "base.rs_impl",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Impl)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Impl),
 )]
 #[case(
     "base.rs_impl-trait",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ImplTrait)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ImplTrait),
 )]
 #[case(
     "base.rs_impl-type",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ImplType)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ImplType),
 )]
 #[case(
     "base.rs_mod",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Mod)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Mod),
 )]
 #[case(
     "base.rs_mod-tests",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::ModTests)),
+    rust::CompiledQuery::from(rust::PreparedQuery::ModTests),
 )]
 #[case(
     "base.rs_typedefs",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::TypeDef)),
+    rust::CompiledQuery::from(rust::PreparedQuery::TypeDef),
 )]
 #[case(
     "base.rs_identifier",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Identifier)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Identifier),
 )]
 #[case(
     "base.rs_type-identifier",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::TypeIdentifier)),
+    rust::CompiledQuery::from(rust::PreparedQuery::TypeIdentifier),
 )]
 #[case(
     "base.rs_closure",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Closure)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Closure),
 )]
 #[case(
     "base.rs_unsafe",
     include_str!("rust/base.rs"),
-    Rust::new(CodeQuery::Prepared(PreparedRustQuery::Unsafe)),
+    rust::CompiledQuery::from(rust::PreparedQuery::Unsafe),
 )]
 #[case(
     "base.tf_variable-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Variable)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Variable),
 )]
 #[case(
     "base.tf_resource-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Resource)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Resource),
 )]
 #[case(
     "base.tf_data-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Data)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Data),
 )]
 #[case(
     "base.tf_output-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Output)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Output),
 )]
 #[case(
     "base.tf_provider-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Provider)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Provider),
 )]
 #[case(
     "base.tf_terraform-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Terraform)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Terraform),
 )]
 #[case(
     "base.tf_locals-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Locals)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Locals),
 )]
 #[case(
     "base.tf_module-block",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Module)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Module),
 )]
 #[case(
     "base.tf_variables",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Variables)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Variables),
 )]
 #[case(
     "base.tf_resource-types",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::ResourceTypes)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::ResourceTypes),
 )]
 #[case(
     "base.tf_resource-names",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::ResourceNames)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::ResourceNames),
 )]
 #[case(
     "base.tf_data-names",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::DataNames)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::DataNames),
 )]
 #[case(
     "base.tf_data-sources",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::DataSources)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::DataSources),
 )]
 #[case(
     "base.tf_comments",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Comments)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Comments),
 )]
 #[case(
     "base.tf_strings",
     include_str!("hcl/base.tf"),
-    Hcl::new(CodeQuery::Prepared(PreparedHclQuery::Strings)),
+    hcl::CompiledQuery::from(hcl::PreparedQuery::Strings),
 )]
 #[case(
     "base.go_comments",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Comments)),
+    go::CompiledQuery::from(go::PreparedQuery::Comments),
 )]
 #[case(
     "base.go_strings",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Strings)),
+    go::CompiledQuery::from(go::PreparedQuery::Strings),
 )]
 #[case(
     "base.go_imports",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Imports)),
+    go::CompiledQuery::from(go::PreparedQuery::Imports),
 )]
 #[case(
     "base.go_type-def",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::TypeDef)),
+    go::CompiledQuery::from(go::PreparedQuery::TypeDef),
 )]
 #[case(
     "base.go_type-alias",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::TypeAlias)),
+    go::CompiledQuery::from(go::PreparedQuery::TypeAlias),
 )]
 #[case(
     "base.go_struct",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Struct)),
+    go::CompiledQuery::from(go::PreparedQuery::Struct),
 )]
 #[case(
     "base.go_interface",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Interface)),
+    go::CompiledQuery::from(go::PreparedQuery::Interface),
 )]
 #[case(
     "base.go_const",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Const)),
+    go::CompiledQuery::from(go::PreparedQuery::Const),
 )]
 #[case(
     "base.go_var",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Var)),
+    go::CompiledQuery::from(go::PreparedQuery::Var),
 )]
 #[case(
     "base.go_func",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Func)),
+    go::CompiledQuery::from(go::PreparedQuery::Func),
 )]
 #[case(
     "base.go_method",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Method)),
+    go::CompiledQuery::from(go::PreparedQuery::Method),
 )]
 #[case(
     "base.go_free-func",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::FreeFunc)),
+    go::CompiledQuery::from(go::PreparedQuery::FreeFunc),
 )]
 #[case(
     "base.go_init-func",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::InitFunc)),
+    go::CompiledQuery::from(go::PreparedQuery::InitFunc),
 )]
 #[case(
     "base.go_type-params",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::TypeParams)),
+    go::CompiledQuery::from(go::PreparedQuery::TypeParams),
 )]
 #[case(
     "base.go_defer",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Defer)),
+    go::CompiledQuery::from(go::PreparedQuery::Defer),
 )]
 #[case(
     "base.go_select",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Select)),
+    go::CompiledQuery::from(go::PreparedQuery::Select),
 )]
 #[case(
     "base.go_go",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Go)),
+    go::CompiledQuery::from(go::PreparedQuery::Go),
 )]
 #[case(
     "base.go_switch",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Switch)),
+    go::CompiledQuery::from(go::PreparedQuery::Switch),
 )]
 #[case(
     "base.go_labeled",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Labeled)),
+    go::CompiledQuery::from(go::PreparedQuery::Labeled),
 )]
 #[case(
     "base.go_goto",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::Goto)),
+    go::CompiledQuery::from(go::PreparedQuery::Goto),
 )]
 #[case(
     "base.go_struct-tags",
     include_str!("go/base.go"),
-    Go::new(CodeQuery::Prepared(PreparedGoQuery::StructTags)),
+    go::CompiledQuery::from(go::PreparedQuery::StructTags),
 )]
 #[case(
     "base.cs_strings",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Strings)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Strings),
 )]
 #[case(
     "base.cs_usings",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Usings)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Usings),
 )]
 #[case(
     "base.cs_comments",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Comments)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Comments),
 )]
 #[case(
     "base.cs_struct",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Struct)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Struct),
 )]
 #[case(
     "base.cs_enum",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Enum)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Enum),
 )]
 #[case(
     "base.cs_field",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Field)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Field),
 )]
 #[case(
     "base.cs_attribute",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Attribute)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Attribute),
 )]
 #[case(
     "base.cs_interface",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Interface)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Interface),
 )]
 #[case(
     "base.cs_class",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Class)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Class),
 )]
 #[case(
     "base.cs_variable_declaration",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::VariableDeclaration)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::VariableDeclaration),
 )]
 #[case(
     "base.cs_property",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Property)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Property),
 )]
 #[case(
     "base.cs_constructor",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Constructor)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Constructor),
 )]
 #[case(
     "base.cs_destructor",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Destructor)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Destructor),
 )]
 #[case(
     "base.cs_method",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Method)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Method),
 )]
 #[case(
     "base.cs_identifier",
     include_str!("csharp/base.cs"),
-    CSharp::new(CodeQuery::Prepared(PreparedCSharpQuery::Identifier)),
+    csharp::CompiledQuery::from(csharp::PreparedQuery::Identifier),
 )]
 #[case(
     "base.c_comments",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Comments)),
+   c::CompiledQuery::from (c::PreparedQuery::Comments),
 )]
 #[case(
     "base.c_strings",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Strings)),
+   c::CompiledQuery::from (c::PreparedQuery::Strings),
 )]
 #[case(
     "base.c_includes",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Includes)),
+   c::CompiledQuery::from (c::PreparedQuery::Includes),
 )]
 #[case(
     "base.c_typedefs",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::TypeDef)),
+   c::CompiledQuery::from (c::PreparedQuery::TypeDef),
 )]
 #[case(
     "base.c_enum",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Enum)),
+   c::CompiledQuery::from (c::PreparedQuery::Enum),
 )]
 #[case(
     "base.c_struct",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Struct)),
+   c::CompiledQuery::from (c::PreparedQuery::Struct),
 )]
 #[case(
     "base.c_variable",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Variable)),
+   c::CompiledQuery::from (c::PreparedQuery::Variable),
 )]
 #[case(
     "base.c_function",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Function)),
+   c::CompiledQuery::from (c::PreparedQuery::Function),
 )]
 #[case(
     "base.c_function_definition",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::FunctionDef)),
+   c::CompiledQuery::from (c::PreparedQuery::FunctionDef),
 )]
 #[case(
     "base.c_function_declaration",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::FunctionDecl)),
+   c::CompiledQuery::from (c::PreparedQuery::FunctionDecl),
 )]
 #[case(
     "base.c_switch",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Switch)),
+   c::CompiledQuery::from (c::PreparedQuery::Switch),
 )]
 #[case(
     "base.c_if",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::If)),
+   c::CompiledQuery::from (c::PreparedQuery::If),
 )]
 #[case(
     "base.c_for",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::For)),
+   c::CompiledQuery::from (c::PreparedQuery::For),
 )]
 #[case(
     "base.c_while",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::While)),
+   c::CompiledQuery::from (c::PreparedQuery::While),
 )]
 #[case(
     "base.c_do",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Do)),
+   c::CompiledQuery::from (c::PreparedQuery::Do),
 )]
 #[case(
     "base.c_union",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Union)),
+   c::CompiledQuery::from (c::PreparedQuery::Union),
 )]
 #[case(
     "base.c_identifier",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Identifier)),
+   c::CompiledQuery::from (c::PreparedQuery::Identifier),
 )]
 #[case(
     "base.c_declaration",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::Declaration)),
+   c::CompiledQuery::from (c::PreparedQuery::Declaration),
 )]
 #[case(
     "base.c_callexpr",
     include_str!("c/base.c"),
-    C::new(CodeQuery::Prepared(PreparedCQuery::CallExpression)),
+   c::CompiledQuery::from (c::PreparedQuery::CallExpression),
 )]
 fn test_language_scopers(
     #[case] snapshot_name: &str,


### PR DESCRIPTION
@alexpovel  I've performed the refactorings we talked about in PR #144 and moved the `handle_language_scope` macro into the `mod cli` so that the fields are and `lang::CompiledQuery`'s are strongly associated.

One of the CLI tests is failing so I'll mark this as WIP.