### PR TITLE
Rename trait `LanguageScoper` to `Query`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Hello YOU!
 Replacement is always performed first and specified positionally. Any [other
 actions](#actions) are applied after and given as command line flags.
 
-### Multiple scopes
+### Multiple queries
 
-Similarly, more than one scope can be specified: in addition to the regex pattern, a
-[**language grammar-aware**]((https://tree-sitter.github.io/tree-sitter/)) scope can be
+Similarly, more than one query can be specified: in addition to the regex pattern, a
+[**language grammar-aware**]((https://tree-sitter.github.io/tree-sitter/)) query can be
 given, which scopes to **syntactical elements of source code** (think, for example, "all
 bodies of `class` definitions in Python"). If both are given, the regular expression
 pattern is then **only applied *within* that first, language scope**. This enables
@@ -115,9 +115,9 @@ $ cat birds.py | srgn --python 'class' 'def .+:\n\s+[^"\s]{3}' # do not try this
 Note how this does not surface either `from_egg` (has a docstring) or `register_bird`
 (not a method, *`def` outside `class`*).
 
-#### Multiple language scopes
+#### Multiple queries
 
-Language scopes themselves can be specified multiple times as well. For example, in the
+Queries themselves can be specified multiple times as well. For example, in the
 Rust snippet
 
 ```rust file=music.rs
@@ -227,7 +227,7 @@ The anatomy of that invocation is:
   (i.e., only take into consideration) docstrings according to the Python language
   grammar
 - `'(?<!The )GNU ([a-z]+)'` (a [scope](#scopes)) sees only what was already scoped by
-  the previous option, and will narrow it down further. It can never extend the previous
+  the previous query option, and will narrow it down further. It can never extend the previous
   scope. The regular expression scope is applied after any language scope(s).
 
   <!-- markdownlint-disable MD038 -->
@@ -782,7 +782,7 @@ language such as `python`. See [below](#custom-queries) for more on this advance
 
 > [!NOTE]
 >
-> Language scopes are applied *first*, so whatever regex aka main scope you pass, it
+> Queries are applied *first*, so whatever regex aka main scope you pass, it
 > operates on each matched language construct individually.
 
 ##### Prepared queries (sample showcases)
@@ -1493,18 +1493,18 @@ Options (global):
           
           The default is to return the input unchanged (without failure).
 
-  -j, --join-language-scopes
-          Join (logical 'OR') multiple language scopes, instead of intersecting them.
+  -j, --join-language-queries
+          Join (logical 'OR') multiple language queries, instead of intersecting them.
           
-          The default when multiple language scopes are given is to intersect their
-          scopes, left to right. For example, `--go func --go strings` will first
-          scope down to `func` bodies, then look for strings only within those. This
-          flag instead joins (in the set logic sense) all scopes. The example would
-          then scope any `func` bodies, and any strings, anywhere. Language scopers
-          can then also be given in any order.
+          The default when multiple language queries are given is to intersect their
+          resulting scopes, left to right. For example, `--go func --go strings` will
+          first scope down to `func` bodies, then look for strings only within those.
+          This flag instead joins (in the set logic sense) all scopes. The example would
+          then scope any `func` bodies, and any strings, anywhere. Queries can then be
+          given in any order.
           
-          No effect if only a single language scope is given. Also does not affect
-          non-language scopers (regex pattern etc.), which always intersect.
+          No effect if only a single query is given. Also does not affect
+          queries without a target language (regex pattern etc.), which always intersect.
 
   -H, --hidden
           Do not ignore hidden files and directories.
@@ -1533,7 +1533,7 @@ Options (global):
           (if unspecified, defaults to 'error'), and increased according to the number
           of times this flag is given, maxing out at 'trace' verbosity.
 
-Language scopes:
+Queries:
       --c <C>
           Scope C code using a prepared query.
           
@@ -2213,7 +2213,7 @@ at your option.
     The original, core version of `srgn` was merely a Rust rewrite of [a previous,
     existing tool](https://github.com/alexpovel/betterletter), which was *only*
     concerned with the *German* feature. `srgn` then grew from there.
-[^3]: With zero actions and no language scoping provided, `srgn` becomes 'useless', and
+[^3]: With zero actions and no queries provided, `srgn` becomes 'useless', and
     other tools such as ripgrep are much more suitable. That's why an error is emitted
     and input is returned unchanged.
 [^4]: Combined with `--fail-any`, the invocation could be used to fail if any `unsafe`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! Anything implementing [`Scoper`] is eligible for use in
 //! [`ScopedViewBuilder::explode`]. This especially includes the language grammar-aware
-//! types, which are [`LanguageScoper`]s. Those may be used as, for example:
+//! types, which are [`Query`]'s. Those may be used as, for example:
 //!
 //! ```rust
 //! use srgn::scoping::langs::{
@@ -174,7 +174,7 @@ use std::ops::Range;
 use crate::{
     actions::Action,
     scoping::{
-        langs::LanguageScoper,
+        langs::Query,
         view::{ScopedView, ScopedViewBuilder},
         Scoper,
     },

--- a/src/scoping/langs/c.rs
+++ b/src/scoping/langs/c.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use clap::ValueEnum;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 
 /// A compiled query for the C language.
@@ -103,7 +103,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_c::LANGUAGE.into()
     }

--- a/src/scoping/langs/csharp.rs
+++ b/src/scoping/langs/csharp.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -108,7 +108,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_c_sharp::LANGUAGE.into()
     }

--- a/src/scoping/langs/go.rs
+++ b/src/scoping/langs/go.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path};
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -133,7 +133,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_go::LANGUAGE.into()
     }

--- a/src/scoping/langs/hcl.rs
+++ b/src/scoping/langs/hcl.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{tree_sitter_hcl, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{tree_sitter_hcl, Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::find::Find;
 use crate::scoping::langs::IGNORE;
 
@@ -332,7 +332,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_hcl::language()
     }

--- a/src/scoping/langs/mod.rs
+++ b/src/scoping/langs/mod.rs
@@ -110,10 +110,8 @@ impl From<String> for RawQuery {
 /// and a result is instead obtained by ignoring unwanted parts of bigger captures.
 pub(super) const IGNORE: &str = "_SRGN_IGNORE";
 
-/// A scoper for a language.
-///
-/// Functions much the same, but provides specific language-related functionality.
-pub trait LanguageScoper: Scoper + Find + Send + Sync {
+/// A query for a language.
+pub trait Query: Scoper + Find + Send + Sync {
     /// The language's tree-sitter language.
     fn lang() -> TSLanguage
     where
@@ -200,20 +198,20 @@ pub trait LanguageScoper: Scoper + Find + Send + Sync {
 
 impl<T> Scoper for T
 where
-    T: LanguageScoper,
+    T: Query,
 {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
         self.scope_via_query(input).into()
     }
 }
 
-impl Scoper for Box<dyn LanguageScoper> {
+impl Scoper for Box<dyn Query> {
     fn scope_raw<'viewee>(&self, input: &'viewee str) -> RangesWithContext<'viewee> {
         self.as_ref().scope_raw(input)
     }
 }
 
-impl Scoper for &[Box<dyn LanguageScoper>] {
+impl Scoper for &[Box<dyn Query>] {
     /// Allows *multiple* scopers to be applied all at once.
     ///
     /// They are OR'd together in the sense that if *any* of the scopers hit, a

--- a/src/scoping/langs/python.rs
+++ b/src/scoping/langs/python.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Find, Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 use crate::scoping::langs::IGNORE;
 
 /// A compiled query for the Python language.
@@ -189,7 +189,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_python::LANGUAGE.into()
     }

--- a/src/scoping/langs/rust.rs
+++ b/src/scoping/langs/rust.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use clap::ValueEnum;
 use const_format::formatcp;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError, IGNORE};
+use super::{Find, Query, RawQuery, TSLanguage, TSQuery, TSQueryError, IGNORE};
 
 /// A compiled query for the Rust language.
 #[derive(Debug)]
@@ -358,7 +358,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_rust::LANGUAGE.into()
     }

--- a/src/scoping/langs/typescript.rs
+++ b/src/scoping/langs/typescript.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use clap::ValueEnum;
 
-use super::{Find, LanguageScoper, RawQuery, TSLanguage, TSQuery, TSQueryError};
+use super::{Find, Query, RawQuery, TSLanguage, TSQuery, TSQueryError};
 
 /// A compiled query for the TypeScript language.
 #[derive(Debug)]
@@ -130,7 +130,7 @@ impl PreparedQuery {
     }
 }
 
-impl LanguageScoper for CompiledQuery {
+impl Query for CompiledQuery {
     fn lang() -> TSLanguage {
         tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
     }

--- a/src/scoping/mod.rs
+++ b/src/scoping/mod.rs
@@ -1,11 +1,5 @@
 //! Items for defining the scope actions are applied within.
 
-use scope::RangesWithContext;
-
-use crate::scoping::scope::ROScopes;
-#[cfg(doc)]
-use crate::scoping::{scope::Scope, view::ScopedView};
-
 /// Fixes for DOS-style line endings.
 pub mod dosfix;
 /// Create scoped views using programming language grammar-aware types.
@@ -18,6 +12,11 @@ pub mod regex;
 pub mod scope;
 /// [`ScopedView`] and its related types.
 pub mod view;
+
+use scope::{ROScopes, RangesWithContext};
+
+#[cfg(doc)]
+use {scope::Scope, view::ScopedView};
 
 /// An item capable of scoping down a given input into individual scopes.
 pub trait Scoper: Send + Sync {

--- a/src/scoping/mod.rs
+++ b/src/scoping/mod.rs
@@ -14,7 +14,6 @@ pub mod scope;
 pub mod view;
 
 use scope::{ROScopes, RangesWithContext};
-
 #[cfg(doc)]
 use {scope::Scope, view::ScopedView};
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -373,7 +373,7 @@ Heizoelrueckstossabdaempfung.
             "--sorted",
             "--python",
             "function-names",
-            "--glob", // Will override language scoper
+            "--glob", // Will override query
             "subdir/**/*.py",
             "foo",
             "baz"
@@ -386,7 +386,7 @@ Heizoelrueckstossabdaempfung.
         &[
             "--python",
             "function-names",
-            "--glob", // Will override language scoper
+            "--glob", // Will override query
             "subdir/**/*.py",
             "foo",
             "baz"

--- a/tests/files/language-scoping-python/in/1-shebanged
+++ b/tests/files/language-scoping-python/in/1-shebanged
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-# Is found and processed by language scoper
+# Is found and processed by query
 
 # This string is not found and touched: foo
 

--- a/tests/files/language-scoping-python/out/1-shebanged
+++ b/tests/files/language-scoping-python/out/1-shebanged
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-# Is found and processed by language scoper
+# Is found and processed by query
 
 # This string is not found and touched: foo
 

--- a/tests/langs/mod.rs
+++ b/tests/langs/mod.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use rstest::rstest;
 use serde::{Deserialize, Serialize};
-use srgn::scoping::langs::{c, csharp, go, hcl, python, rust, typescript, LanguageScoper};
+use srgn::scoping::langs::{c, csharp, go, hcl, python, rust, typescript, Query};
 use srgn::scoping::scope::Scope;
 use srgn::scoping::view::ScopedViewBuilder;
 
@@ -818,13 +818,9 @@ impl InScopeLinePart {
     include_str!("c/base.c"),
    c::CompiledQuery::from (c::PreparedQuery::CallExpression),
 )]
-fn test_language_scopers(
-    #[case] snapshot_name: &str,
-    #[case] contents: &str,
-    #[case] lang: impl LanguageScoper,
-) {
+fn test_queries(#[case] snapshot_name: &str, #[case] contents: &str, #[case] query: impl Query) {
     let mut builder = ScopedViewBuilder::new(contents);
-    builder.explode(&lang);
+    builder.explode(&query);
     let view = builder.build();
 
     // Collect only those lines which are in scope. This avoids enormous clutter from


### PR DESCRIPTION
The use of `LanguageScoper` is a type seems to be a misnomer.
 
`Query` is implemented on a `CompiledQuery` and a `LanguageScoper` is used to query a given set of text to produce a list of `Scope`'s.

With this rename, a `lang::Query` produces `Scope`'s and 'language scoping` in a process that accepts `Query`'s as input and outputs `Scope`'s.