### PR TITLE
fix(cli): Ignore (do not abort on) non-utf8 files when walking recurs…

### DIFF
--- a/tests/files/binary-data/in/invalid-utf8
+++ b/tests/files/binary-data/in/invalid-utf8
@@ -1,0 +1,3 @@
+# DO NOT save this file in an editor: it will overwrite the invalid file marker with a
+# literal ï¿½, which is valid utf-8
+invalid utf8 ÿ

--- a/tests/files/binary-data/in/subdir/invalid-utf8
+++ b/tests/files/binary-data/in/subdir/invalid-utf8
@@ -1,0 +1,3 @@
+# DO NOT save this file in an editor: it will overwrite the invalid file marker with a
+# literal ï¿½, which is valid utf-8
+invalid utf8 ÿ

--- a/tests/files/binary-data/in/subdir/valid-utf8
+++ b/tests/files/binary-data/in/subdir/valid-utf8
@@ -1,0 +1,2 @@
+valid utf8
+unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8

--- a/tests/files/binary-data/out/invalid-utf8
+++ b/tests/files/binary-data/out/invalid-utf8
@@ -1,0 +1,3 @@
+# DO NOT save this file in an editor: it will overwrite the invalid file marker with a
+# literal ï¿½, which is valid utf-8
+invalid utf8 ÿ

--- a/tests/files/binary-data/out/subdir/invalid-utf8
+++ b/tests/files/binary-data/out/subdir/invalid-utf8
@@ -1,0 +1,3 @@
+# DO NOT save this file in an editor: it will overwrite the invalid file marker with a
+# literal ï¿½, which is valid utf-8
+invalid utf8 ÿ

--- a/tests/files/binary-data/out/subdir/valid-utf8
+++ b/tests/files/binary-data/out/subdir/valid-utf8
@@ -1,0 +1,2 @@
+valid utf8
+unique string for precise searching: gone

--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-linux.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-linux.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir/valid-utf8\n"
+  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "2:unique string for precise searching: gone\n"
+  - "\n"
+exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-macos.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-macos.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir/valid-utf8\n"
+  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "2:unique string for precise searching: gone\n"
+  - "\n"
+exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-windows.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-windows.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir\\valid-utf8\n"
+  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "2:unique string for precise searching: gone\n"
+  - "\n"
+exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-linux.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-linux.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir/valid-utf8\n"
+exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-macos.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-macos.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir/valid-utf8\n"
+exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-windows.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-windows.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli.rs
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+info:
+  stderr: []
+---
+args:
+  - "--sorted"
+  - "--glob"
+  - "**/*"
+  - 0a1a09c8-2995-4ac5-9d60-01a0f02920e8
+  - gone
+stdin: ~
+stdout:
+  - "subdir\\valid-utf8\n"
+exit_code: 0


### PR DESCRIPTION
…ively

Previously a hard error, but safest bet seems to
ignore. Ripgrep handles binary data with NUL byte
detection, which does not seem necessary here

Closes #166