### PR TITLE
Parseable output format

### DIFF
--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-linux.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-linux.snap
@@ -13,8 +13,6 @@ args:
   - gone
 stdin: ~
 stdout:
-  - "subdir/valid-utf8\n"
-  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
-  - "2:unique string for precise searching: gone\n"
-  - "\n"
+  - "subdir/valid-utf8:2:37-73:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "subdir/valid-utf8:2:37-41:unique string for precise searching: gone\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-macos.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-macos.snap
@@ -13,8 +13,6 @@ args:
   - gone
 stdin: ~
 stdout:
-  - "subdir/valid-utf8\n"
-  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
-  - "2:unique string for precise searching: gone\n"
-  - "\n"
+  - "subdir/valid-utf8:2:37-73:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "subdir/valid-utf8:2:37-41:unique string for precise searching: gone\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__binary-data-sorted-dry-run-windows.snap
+++ b/tests/snapshots/cli__tests__binary-data-sorted-dry-run-windows.snap
@@ -13,8 +13,6 @@ args:
   - gone
 stdin: ~
 stdout:
-  - "subdir\\valid-utf8\n"
-  - "2:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
-  - "2:unique string for precise searching: gone\n"
-  - "\n"
+  - "subdir\\valid-utf8:2:37-73:unique string for precise searching: 0a1a09c8-2995-4ac5-9d60-01a0f02920e8\n"
+  - "subdir\\valid-utf8:2:37-41:unique string for precise searching: gone\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__files-inplace-python-dry-run-linux.snap
+++ b/tests/snapshots/cli__tests__files-inplace-python-dry-run-linux.snap
@@ -13,18 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1.py\n"
-  - "1:# This string is found and touched: foo\n"
-  - "1:# This string is found and touched: baz\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1.py:1:36-39:# This string is found and touched: foo\n"
+  - "1.py:1:36-39:# This string is found and touched: baz\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__files-inplace-python-dry-run-macos.snap
+++ b/tests/snapshots/cli__tests__files-inplace-python-dry-run-macos.snap
@@ -13,18 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1.py\n"
-  - "1:# This string is found and touched: foo\n"
-  - "1:# This string is found and touched: baz\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1.py:1:36-39:# This string is found and touched: foo\n"
+  - "1.py:1:36-39:# This string is found and touched: baz\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__files-inplace-python-dry-run-windows.snap
+++ b/tests/snapshots/cli__tests__files-inplace-python-dry-run-windows.snap
@@ -13,18 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1.py\n"
-  - "1:# This string is found and touched: foo\n"
-  - "1:# This string is found and touched: baz\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir\\2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir\\subdir\\3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1.py:1:36-39:# This string is found and touched: foo\n"
+  - "1.py:1:36-39:# This string is found and touched: baz\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir\\2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__go-ignores-vendor-directory.snap
+++ b/tests/snapshots/cli__tests__go-ignores-vendor-directory.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: None,\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin: None, stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -9,7 +9,5 @@ args:
   - comments
 stdin: ~
 stdout:
-  - "found.go\n"
-  - "3:// This is found\n"
-  - "\n"
+  - "found.go:3:0-16:// This is found\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__go-search-files-linux.snap
+++ b/tests/snapshots/cli__tests__go-search-files-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,10 +11,8 @@ args:
   - "[fF]izz"
 stdin: ~
 stdout:
-  - "tests/langs/go/fizzbuzz.go\n"
-  - "5:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
-  - "6:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
-  - "8:// it prints \"FizzBuzz\".\n"
-  - "25:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
-  - "\n"
+  - "tests/langs/go/fizzbuzz.go:5:3-7:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
+  - "tests/langs/go/fizzbuzz.go:6:34-38:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
+  - "tests/langs/go/fizzbuzz.go:8:14-18:// it prints \"FizzBuzz\".\n"
+  - "tests/langs/go/fizzbuzz.go:25:12-16:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__go-search-files-macos.snap
+++ b/tests/snapshots/cli__tests__go-search-files-macos.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,10 +11,8 @@ args:
   - "[fF]izz"
 stdin: ~
 stdout:
-  - "tests/langs/go/fizzbuzz.go\n"
-  - "5:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
-  - "6:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
-  - "8:// it prints \"FizzBuzz\".\n"
-  - "25:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
-  - "\n"
+  - "tests/langs/go/fizzbuzz.go:5:3-7:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
+  - "tests/langs/go/fizzbuzz.go:6:34-38:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
+  - "tests/langs/go/fizzbuzz.go:8:14-18:// it prints \"FizzBuzz\".\n"
+  - "tests/langs/go/fizzbuzz.go:25:12-16:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__go-search-files-windows.snap
+++ b/tests/snapshots/cli__tests__go-search-files-windows.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,10 +11,8 @@ args:
   - "[fF]izz"
 stdin: ~
 stdout:
-  - "tests\\langs\\go\\fizzbuzz.go\n"
-  - "5:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
-  - "6:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
-  - "8:// it prints \"FizzBuzz\".\n"
-  - "25:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
-  - "\n"
+  - "tests\\langs\\go\\fizzbuzz.go:5:3-7:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
+  - "tests\\langs\\go\\fizzbuzz.go:6:34-38:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
+  - "tests\\langs\\go\\fizzbuzz.go:8:14-18:// it prints \"FizzBuzz\".\n"
+  - "tests\\langs\\go\\fizzbuzz.go:25:12-16:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__go-search.snap
+++ b/tests/snapshots/cli__tests__go-search.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--go"
@@ -37,8 +37,8 @@ stdin:
   - "\tfizzBuzz(100)\n"
   - "}\n"
 stdout:
-  - "5:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
-  - "6:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
-  - "8:// it prints \"FizzBuzz\".\n"
-  - "25:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
+  - "(stdin):5:3-7:// fizzBuzz prints the numbers from 1 to a specified limit.\n"
+  - "(stdin):6:34-38:// For multiples of 3, it prints \"Fizz\" instead of the number,\n"
+  - "(stdin):8:14-18:// it prints \"FizzBuzz\".\n"
+  - "(stdin):25:12-16:\t// Run the FizzBuzz function for numbers from 1 to 100\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-linux.snap
+++ b/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-linux.snap
@@ -15,12 +15,8 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-macos.snap
+++ b/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-macos.snap
@@ -15,12 +15,8 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-windows.snap
+++ b/tests/snapshots/cli__tests__language-scoping-and-files-inplace-python-dry-run-windows.snap
@@ -15,12 +15,8 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "subdir\\2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir\\subdir\\3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "subdir\\2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-linux.snap
+++ b/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-linux.snap
@@ -13,20 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1-shebanged\n"
-  - "9:def foo(bar: int) -> int:\n"
-  - "9:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "1.py\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1-shebanged:9:4-7:def foo(bar: int) -> int:\n"
+  - "1-shebanged:9:4-7:def baz(bar: int) -> int:\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-macos.snap
+++ b/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-macos.snap
@@ -13,20 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1-shebanged\n"
-  - "9:def foo(bar: int) -> int:\n"
-  - "9:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "1.py\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir/subdir/3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1-shebanged:9:4-7:def foo(bar: int) -> int:\n"
+  - "1-shebanged:9:4-7:def baz(bar: int) -> int:\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir/subdir/3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-windows.snap
+++ b/tests/snapshots/cli__tests__language-scoping-inplace-python-dry-run-windows.snap
@@ -13,20 +13,12 @@ args:
   - baz
 stdin: ~
 stdout:
-  - "1-shebanged\n"
-  - "9:def foo(bar: int) -> int:\n"
-  - "9:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "1.py\n"
-  - "4:def foo(bar: int) -> int:\n"
-  - "4:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir\\2.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
-  - "subdir\\subdir\\3.py\n"
-  - "1:def foo(bar: int) -> int:\n"
-  - "1:def baz(bar: int) -> int:\n"
-  - "\n"
+  - "1-shebanged:9:4-7:def foo(bar: int) -> int:\n"
+  - "1-shebanged:9:4-7:def baz(bar: int) -> int:\n"
+  - "1.py:4:4-7:def foo(bar: int) -> int:\n"
+  - "1.py:4:4-7:def baz(bar: int) -> int:\n"
+  - "subdir\\2.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\2.py:1:4-7:def baz(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def foo(bar: int) -> int:\n"
+  - "subdir\\subdir\\3.py:1:4-7:def baz(bar: int) -> int:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__line-numbers-outside-search-mode.snap
+++ b/tests/snapshots/cli__tests__line-numbers-outside-search-mode.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -12,6 +12,6 @@ stdin:
   - "A\n"
   - B
 stdout:
-  - "1:X\n"
-  - "2:B"
+  - "(stdin):1:0-1:X\n"
+  - "(stdin):2::B"
 exit_code: 0

--- a/tests/snapshots/cli__tests__only-matching-and-line-numbers-no-actions-outside-search-mode.snap
+++ b/tests/snapshots/cli__tests__only-matching-and-line-numbers-no-actions-outside-search-mode.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -11,6 +11,6 @@ stdin:
   - "A\n"
   - B
 stdout:
-  - "1:A\n"
-  - "2:B"
+  - "(stdin):1:0-1:A\n"
+  - "(stdin):2:0-1:B"
 exit_code: 0

--- a/tests/snapshots/cli__tests__only-matching-and-line-numbers-outside-search-mode.snap
+++ b/tests/snapshots/cli__tests__only-matching-and-line-numbers-outside-search-mode.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -13,5 +13,5 @@ stdin:
   - "A\n"
   - B
 stdout:
-  - "1:X\n"
+  - "(stdin):1:0-1:X\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__only-matching-outside-search-mode.snap
+++ b/tests/snapshots/cli__tests__only-matching-outside-search-mode.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -12,5 +12,5 @@ stdin:
   - "A\n"
   - B
 stdout:
-  - "X\n"
+  - "(stdin):0-1:X\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-multiple-scopes.snap
+++ b/tests/snapshots/cli__tests__python-multiple-scopes.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
   stderr: []
 ---
@@ -16,5 +16,5 @@ stdin:
   - "def A(): return \"A string in a func\"\n"
   - "class A: pass"
 stdout:
-  - "3:def A(): return \"A string in a func\"\n"
+  - "(stdin):3:17-18:def A(): return \"A string in a func\"\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-files-linux.snap
+++ b/tests/snapshots/cli__tests__python-search-files-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,20 +11,18 @@ args:
   - is
 stdin: ~
 stdout:
-  - "tests/langs/python/base.py\n"
-  - "24:    print(f\"Global test_var is now {test_var}\")\n"
-  - "66:        print(f\"Class variable is now {cls.class_var}\")\n"
-  - "72:        print(f\"Instance variable is {self.instance_var}\")\n"
-  - "86:This is a\n"
-  - "91:multiline_f_string = f\"\"\"This is a\n"
-  - "96:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
-  - "97:bytes_string = b\"This is a bytes string\"\n"
-  - "98:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
-  - "118:            raise ZeroDivisionError(\"Division by zero\")\n"
-  - "127:        print(\"This will always be printed\")\n"
-  - "140:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
-  - "158:        print(\"test_var is greater than 5\")\n"
-  - "160:        print(\"test_var is 5 or less\")\n"
-  - "165:        print(f\"Counter is {counter}\")\n"
-  - "\n"
+  - "tests/langs/python/base.py:24:28-30:    print(f\"Global test_var is now {test_var}\")\n"
+  - "tests/langs/python/base.py:66:31-33:        print(f\"Class variable is now {cls.class_var}\")\n"
+  - "tests/langs/python/base.py:72:34-36:        print(f\"Instance variable is {self.instance_var}\")\n"
+  - "tests/langs/python/base.py:86:2-4;5-7:This is a\n"
+  - "tests/langs/python/base.py:91:27-29;30-32:multiline_f_string = f\"\"\"This is a\n"
+  - "tests/langs/python/base.py:96:17-19;20-22:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
+  - "tests/langs/python/base.py:97:19-21;22-24:bytes_string = b\"This is a bytes string\"\n"
+  - "tests/langs/python/base.py:98:20-22;23-25:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
+  - "tests/langs/python/base.py:118:40-42:            raise ZeroDivisionError(\"Division by zero\")\n"
+  - "tests/langs/python/base.py:127:17-19:        print(\"This will always be printed\")\n"
+  - "tests/langs/python/base.py:140:30-32:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
+  - "tests/langs/python/base.py:158:24-26:        print(\"test_var is greater than 5\")\n"
+  - "tests/langs/python/base.py:160:24-26:        print(\"test_var is 5 or less\")\n"
+  - "tests/langs/python/base.py:165:24-26:        print(f\"Counter is {counter}\")\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-files-macos.snap
+++ b/tests/snapshots/cli__tests__python-search-files-macos.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,20 +11,18 @@ args:
   - is
 stdin: ~
 stdout:
-  - "tests/langs/python/base.py\n"
-  - "24:    print(f\"Global test_var is now {test_var}\")\n"
-  - "66:        print(f\"Class variable is now {cls.class_var}\")\n"
-  - "72:        print(f\"Instance variable is {self.instance_var}\")\n"
-  - "86:This is a\n"
-  - "91:multiline_f_string = f\"\"\"This is a\n"
-  - "96:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
-  - "97:bytes_string = b\"This is a bytes string\"\n"
-  - "98:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
-  - "118:            raise ZeroDivisionError(\"Division by zero\")\n"
-  - "127:        print(\"This will always be printed\")\n"
-  - "140:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
-  - "158:        print(\"test_var is greater than 5\")\n"
-  - "160:        print(\"test_var is 5 or less\")\n"
-  - "165:        print(f\"Counter is {counter}\")\n"
-  - "\n"
+  - "tests/langs/python/base.py:24:28-30:    print(f\"Global test_var is now {test_var}\")\n"
+  - "tests/langs/python/base.py:66:31-33:        print(f\"Class variable is now {cls.class_var}\")\n"
+  - "tests/langs/python/base.py:72:34-36:        print(f\"Instance variable is {self.instance_var}\")\n"
+  - "tests/langs/python/base.py:86:2-4;5-7:This is a\n"
+  - "tests/langs/python/base.py:91:27-29;30-32:multiline_f_string = f\"\"\"This is a\n"
+  - "tests/langs/python/base.py:96:17-19;20-22:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
+  - "tests/langs/python/base.py:97:19-21;22-24:bytes_string = b\"This is a bytes string\"\n"
+  - "tests/langs/python/base.py:98:20-22;23-25:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
+  - "tests/langs/python/base.py:118:40-42:            raise ZeroDivisionError(\"Division by zero\")\n"
+  - "tests/langs/python/base.py:127:17-19:        print(\"This will always be printed\")\n"
+  - "tests/langs/python/base.py:140:30-32:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
+  - "tests/langs/python/base.py:158:24-26:        print(\"test_var is greater than 5\")\n"
+  - "tests/langs/python/base.py:160:24-26:        print(\"test_var is 5 or less\")\n"
+  - "tests/langs/python/base.py:165:24-26:        print(f\"Counter is {counter}\")\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-files-windows.snap
+++ b/tests/snapshots/cli__tests__python-search-files-windows.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--sorted"
@@ -11,20 +11,18 @@ args:
   - is
 stdin: ~
 stdout:
-  - "tests\\langs\\python\\base.py\n"
-  - "24:    print(f\"Global test_var is now {test_var}\")\n"
-  - "66:        print(f\"Class variable is now {cls.class_var}\")\n"
-  - "72:        print(f\"Instance variable is {self.instance_var}\")\n"
-  - "86:This is a\n"
-  - "91:multiline_f_string = f\"\"\"This is a\n"
-  - "96:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
-  - "97:bytes_string = b\"This is a bytes string\"\n"
-  - "98:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
-  - "118:            raise ZeroDivisionError(\"Division by zero\")\n"
-  - "127:        print(\"This will always be printed\")\n"
-  - "140:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
-  - "158:        print(\"test_var is greater than 5\")\n"
-  - "160:        print(\"test_var is 5 or less\")\n"
-  - "165:        print(f\"Counter is {counter}\")\n"
-  - "\n"
+  - "tests\\langs\\python\\base.py:24:28-30:    print(f\"Global test_var is now {test_var}\")\n"
+  - "tests\\langs\\python\\base.py:66:31-33:        print(f\"Class variable is now {cls.class_var}\")\n"
+  - "tests\\langs\\python\\base.py:72:34-36:        print(f\"Instance variable is {self.instance_var}\")\n"
+  - "tests\\langs\\python\\base.py:86:2-4;5-7:This is a\n"
+  - "tests\\langs\\python\\base.py:91:27-29;30-32:multiline_f_string = f\"\"\"This is a\n"
+  - "tests\\langs\\python\\base.py:96:17-19;20-22:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
+  - "tests\\langs\\python\\base.py:97:19-21;22-24:bytes_string = b\"This is a bytes string\"\n"
+  - "tests\\langs\\python\\base.py:98:20-22;23-25:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
+  - "tests\\langs\\python\\base.py:118:40-42:            raise ZeroDivisionError(\"Division by zero\")\n"
+  - "tests\\langs\\python\\base.py:127:17-19:        print(\"This will always be printed\")\n"
+  - "tests\\langs\\python\\base.py:140:30-32:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
+  - "tests\\langs\\python\\base.py:158:24-26:        print(\"test_var is greater than 5\")\n"
+  - "tests\\langs\\python\\base.py:160:24-26:        print(\"test_var is 5 or less\")\n"
+  - "tests\\langs\\python\\base.py:165:24-26:        print(f\"Counter is {counter}\")\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-stdin-across-lines.snap
+++ b/tests/snapshots/cli__tests__python-search-stdin-across-lines.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--python"
@@ -221,6 +221,6 @@ stdin:
   - "    match_statement(1)\n"
   - "    asyncio.run(async_function())\n"
 stdout:
-  - "62:    @classmethod\n"
-  - "63:    def class_method(cls) -> None:\n"
+  - "(stdin):62:4-17:    @classmethod\n"
+  - "(stdin):63:0-20:    def class_method(cls) -> None:\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-stdin-and-files.snap
+++ b/tests/snapshots/cli__tests__python-search-stdin-and-files.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: "[ERROR srgn] Detected stdin, and request for files: will use stdin and ignore files.\n"
+  stderr: []
 ---
 args:
   - "--python"
@@ -223,18 +223,18 @@ stdin:
   - "    match_statement(1)\n"
   - "    asyncio.run(async_function())\n"
 stdout:
-  - "24:    print(f\"Global test_var is now {test_var}\")\n"
-  - "66:        print(f\"Class variable is now {cls.class_var}\")\n"
-  - "72:        print(f\"Instance variable is {self.instance_var}\")\n"
-  - "86:This is a\n"
-  - "91:multiline_f_string = f\"\"\"This is a\n"
-  - "96:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
-  - "97:bytes_string = b\"This is a bytes string\"\n"
-  - "98:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
-  - "118:            raise ZeroDivisionError(\"Division by zero\")\n"
-  - "127:        print(\"This will always be printed\")\n"
-  - "140:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
-  - "158:        print(\"test_var is greater than 5\")\n"
-  - "160:        print(\"test_var is 5 or less\")\n"
-  - "165:        print(f\"Counter is {counter}\")\n"
+  - "(stdin):24:28-30:    print(f\"Global test_var is now {test_var}\")\n"
+  - "(stdin):66:31-33:        print(f\"Class variable is now {cls.class_var}\")\n"
+  - "(stdin):72:34-36:        print(f\"Instance variable is {self.instance_var}\")\n"
+  - "(stdin):86:2-4;5-7:This is a\n"
+  - "(stdin):91:27-29;30-32:multiline_f_string = f\"\"\"This is a\n"
+  - "(stdin):96:17-19;20-22:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
+  - "(stdin):97:19-21;22-24:bytes_string = b\"This is a bytes string\"\n"
+  - "(stdin):98:20-22;23-25:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
+  - "(stdin):118:40-42:            raise ZeroDivisionError(\"Division by zero\")\n"
+  - "(stdin):127:17-19:        print(\"This will always be printed\")\n"
+  - "(stdin):140:30-32:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
+  - "(stdin):158:24-26:        print(\"test_var is greater than 5\")\n"
+  - "(stdin):160:24-26:        print(\"test_var is 5 or less\")\n"
+  - "(stdin):165:24-26:        print(f\"Counter is {counter}\")\n"
 exit_code: 0

--- a/tests/snapshots/cli__tests__python-search-stdin.snap
+++ b/tests/snapshots/cli__tests__python-search-stdin.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/cli.rs
-expression: "CommandSnap {\n    args,\n    stdin: stdin.map(|s|\n            s.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec()),\n    stdout: stdout.split_inclusive('\\n').map(|s| s.to_owned()).collect_vec(),\n    exit_code,\n}"
+expression: "CommandSnap\n{\n    args, stdin:\n    stdin.map(|s|\n    s.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec()), stdout:\n    stdout.split_inclusive('\\n').map(ToOwned::to_owned).collect_vec(),\n    exit_code,\n}"
 info:
-  stderr: ""
+  stderr: []
 ---
 args:
   - "--python"
@@ -221,18 +221,18 @@ stdin:
   - "    match_statement(1)\n"
   - "    asyncio.run(async_function())\n"
 stdout:
-  - "24:    print(f\"Global test_var is now {test_var}\")\n"
-  - "66:        print(f\"Class variable is now {cls.class_var}\")\n"
-  - "72:        print(f\"Instance variable is {self.instance_var}\")\n"
-  - "86:This is a\n"
-  - "91:multiline_f_string = f\"\"\"This is a\n"
-  - "96:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
-  - "97:bytes_string = b\"This is a bytes string\"\n"
-  - "98:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
-  - "118:            raise ZeroDivisionError(\"Division by zero\")\n"
-  - "127:        print(\"This will always be printed\")\n"
-  - "140:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
-  - "158:        print(\"test_var is greater than 5\")\n"
-  - "160:        print(\"test_var is 5 or less\")\n"
-  - "165:        print(f\"Counter is {counter}\")\n"
+  - "(stdin):24:28-30:    print(f\"Global test_var is now {test_var}\")\n"
+  - "(stdin):66:31-33:        print(f\"Class variable is now {cls.class_var}\")\n"
+  - "(stdin):72:34-36:        print(f\"Instance variable is {self.instance_var}\")\n"
+  - "(stdin):86:2-4;5-7:This is a\n"
+  - "(stdin):91:27-29;30-32:multiline_f_string = f\"\"\"This is a\n"
+  - "(stdin):96:17-19;20-22:raw_string = r\"This is a raw string with no special treatment for \\n\"\n"
+  - "(stdin):97:19-21;22-24:bytes_string = b\"This is a bytes string\"\n"
+  - "(stdin):98:20-22;23-25:bytes_string = rf\"This is a raw f-string with {raw_string}\"\n"
+  - "(stdin):118:40-42:            raise ZeroDivisionError(\"Division by zero\")\n"
+  - "(stdin):127:17-19:        print(\"This will always be printed\")\n"
+  - "(stdin):140:30-32:    print(f\"Nonlocal variable is {nonlocal_var}\")\n"
+  - "(stdin):158:24-26:        print(\"test_var is greater than 5\")\n"
+  - "(stdin):160:24-26:        print(\"test_var is 5 or less\")\n"
+  - "(stdin):165:24-26:        print(f\"Counter is {counter}\")\n"
 exit_code: 0


### PR DESCRIPTION
This change adds a machine-readable output format.
`srgn` tries to detect automatically if it should
be used by probing if standard output is a TTY. If
it is not, this new format is used. If it is, the
known, current format is used (which remains
unchanged).

The output format is designed for further
processing in downstream scripts. It works
similarly to ripgrep.

This is all a bit ad-hoc and crappy - something
structured and well-known like JSON might be nice.
It could be added, though the current approach is
already pretty spaghetti.