### PR TITLE
feat(cli): `stdin-detection` option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -419,6 +419,6 @@ jobs:
         # Because it's hard to test, this isn't asserted against anything. Just a nice
         # final check. Requires overriding stdin as that is unfortunately detected as
         # present in GitHub Actions. Should not be necessary in normal CLI use.
-        run: srgn -vvvv --stdin-override-to false --rust struct
+        run: srgn -vvvv --stdin-detection force-unreadable --rust struct
       - name: Perform dummy run (minimal verbosity)
-        run: srgn --stdin-override-to false --rust struct
+        run: srgn --stdin-detection force-unreadable --rust struct

--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,16 @@ Options (global):
           
           Sorted processing disables parallel processing.
 
+      --stdin-detection <STDIN_DETECTION>
+          Control heuristics for stdin readability detection, and force to value.
+          
+          [default: auto]
+
+          Possible values:
+          - auto:             Automatically detect if stdin is readable
+          - force-readable:   Act as if stdin is readable
+          - force-unreadable: Act as if stdin is not readable
+
       --stdout-detection <STDOUT_DETECTION>
           Control heuristics for stdout detection, and potentially force to value.
           

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -308,7 +308,7 @@ Heizoelrueckstossabdaempfung.
             cmd.args(
                 // Override; `Command` is detected as providing stdin but we're working on
                 // files here.
-                ["--stdin-override-to", "false"],
+                ["--stdin-detection", "force-unreadable"],
             );
         }
 
@@ -458,7 +458,7 @@ Heizoelrueckstossabdaempfung.
         cmd.args(
             // Override; `Command` is detected as providing stdin but we're working on
             // files here.
-            ["--stdin-override-to", "false"],
+            ["--stdin-detection", "force-unreadable"],
         );
         cmd.args(&args);
         if dry_run {
@@ -786,7 +786,7 @@ Heizoelrueckstossabdaempfung.
             cmd.args(
                 // Override; `Command` is detected as providing stdin but we're working on
                 // files here.
-                ["--stdin-override-to", "false"],
+                ["--stdin-detection", "force-unreadable"],
             );
         }
         cmd.args(&args);

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -170,9 +170,10 @@ mod tests {
         /// For that scenario, we need a hacky method to disable stdin for good.
         fn force_ignore_stdin(&mut self) {
             match self {
-                Self::Self_(inv) => inv
-                    .opts
-                    .push(Opt::Long("stdin-override-to".into(), "false".into())),
+                Self::Self_(inv) => inv.opts.push(Opt::Long(
+                    "stdin-detection".into(),
+                    "force-unreadable".into(),
+                )),
                 _ => panic!("Forcing stdin ignore only applicable to `self` program"),
             }
         }
@@ -533,8 +534,8 @@ mod tests {
                                 )),
                                 // Misc. flags used in the docs
                                 alt((
-                                    tag("stdin-override-to"),
                                     tag("stdout-detection"),
+                                    tag("stdin-detection"),
                                     tag("threads"),
                                     tag("glob"),
                                 )),


### PR DESCRIPTION
This aligns stdin detection option handling on the CLI to how it is done for stdout already, since
1d64ef28ec6698b0e929f4422630e4833e96e603.

Considered not a breaking change, as this was not
documented before.

Closes #137.